### PR TITLE
Allow youtube in iframes

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -21,6 +21,7 @@ backend:
         connect-src: [ "'self'", 'http:', 'https:' ]
         img-src: [ "'self'", "*.gov.bc.ca", "data:" ]
         script-src: [ "'self'", "*.gov.bc.ca" ]
+        frame-src: ["www.youtube.com"]
         # Content-Security-Policy directives follow the Helmet format: https://helmetjs.github.io/#reference
         # Default Helmet Content-Security-Policy values can be removed by setting the key to false
     cors:
@@ -67,6 +68,9 @@ techdocs:
         runIn: 'docker' # Alternatives - 'local'
     publisher:
         type: 'local' # Alternatives - 'googleGcs' or 'awsS3'. Read documentation for using alternatives.
+    sanitizer:
+        allowedIframeHosts:
+            - www.youtube.com
 
 auth:
     # see https://backstage.io/docs/auth/ to learn about auth providers


### PR DESCRIPTION
This is for Jira ticket: DEVX-236

- Updated the tecdocs config as [discussed in this issue](https://github.com/backstage/backstage/issues/15343)
- Updated the csp config to allow content from YouTube in iframes

Examples of pages that have YouTube embedded content which is currently not displayed:
- [Install the oc command line tool](https://mvp.developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/openshift-projects-and-access/install-the-oc-command-line-tool/)
- [Training from the Platform Services team](https://mvp.developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/training-and-learning/training-from-the-platform-services-team/)

The YouTube videos are not displayed. The original pages have YouTube videos embedded in them