### PR TITLE
Update GitHub actions versions

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -33,11 +33,11 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
     
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ env.REPOSITORY_NAME }}
           # Always generate latest tag (https://github.com/docker/metadata-action#latest-tag)
@@ -47,7 +47,7 @@ jobs:
             type=sha
             type=ref,event=pr
       - name: Login to GHCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -55,11 +55,11 @@ jobs:
       - 
         # Support for multiplatform build. Using for dev debugging
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
               
       - # Support for multiplatform build. Using for dev debugging
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         
       - name: Build container
         uses: docker/build-push-action@v4
@@ -84,7 +84,7 @@ jobs:
           ssh-private-key: ${{ secrets.MANIFEST_REPO_DEPLOY_KEY }}  
 
       - name: Checkout CD repo
-        uses: actions/checkout@v3   
+        uses: actions/checkout@v4   
         with:
           ssh-key: ${{ secrets.MANIFEST_REPO_DEPLOY_KEY }}
           repository: ${{ secrets.MANIFEST_REPO }}

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout backstage'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
Bump docker/login-action from 2 to 3
Bump docker/metadata-action from 4 to 5
Bump actions/checkout from 3 to 4
Bump docker/setup-qemu-action from 2 to 3
Bump docker/setup-buildx-action from 2 to 3

dependabot put in 5 PRs (PR #60 #61 #62 #63 #64) to update versions, I've squashed them all into one commit in this PR