### PR TITLE
Devx973 improve snowplow links

### DIFF
--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useEffect } from 'react';
 import { makeStyles } from '@material-ui/core';
 import HomeIcon from '@material-ui/icons/Home';
 // import CatalogIcon from '@material-ui/icons/LocalLibrary';
@@ -39,12 +39,21 @@ import {useApi, configApiRef} from '@backstage/core-plugin-api';
 import {newTracker, trackPageView, enableActivityTracking} from '@snowplow/browser-tracker';
 import {
     enableLinkClickTracking,
+    refreshLinkClickTracking,
     LinkClickTrackingPlugin as linkTrackingPlugin
 } from '@snowplow/browser-plugin-link-click-tracking';
+import {useLocation} from "react-router-dom";
 
 
 const MyReactComponent = () => {
     const config = useApi(configApiRef);
+
+    const location = useLocation();
+
+    // refresh link tracking whenever local navigation occurs
+    useEffect(() => {
+      setTimeout(refreshLinkClickTracking, 250)
+    }, [location]);
 
     console.log("**********Setting up analytics (or not...)********");
     console.log(`Config: ${JSON.stringify(config)}`);

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -52,7 +52,7 @@ const MyReactComponent = () => {
 
     // refresh link tracking whenever local navigation occurs
     useEffect(() => {
-      setTimeout(refreshLinkClickTracking, 250)
+      setTimeout(refreshLinkClickTracking, 250);
     }, [location]);
 
     console.log("**********Setting up analytics (or not...)********");

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -173,7 +173,7 @@ const HomePage = () => {
 
 	const handleExpandClick = () => {
 	  setExpanded(!expanded);
-	  setTimeout(refreshLinkClickTracking, 250)
+	  setTimeout(refreshLinkClickTracking, 250);
 	};
 
 	return (

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -10,6 +10,7 @@ import LockIcon from '@material-ui/icons/Lock';
 import { Link } from 'react-router-dom';
 import IconButton, { IconButtonProps } from '@mui/material/IconButton';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { refreshLinkClickTracking } from '@snowplow/browser-plugin-link-click-tracking';
 
 const useStyles = makeStyles(theme => ({
 	searchBar: {
@@ -172,6 +173,7 @@ const HomePage = () => {
 
 	const handleExpandClick = () => {
 	  setExpanded(!expanded);
+	  setTimeout(refreshLinkClickTracking, 250)
 	};
 
 	return (

--- a/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/app/src/components/search/SearchPage.tsx
@@ -23,6 +23,7 @@ import {
 import { useApi } from '@backstage/core-plugin-api';
 import { StackOverflowIcon } from '@backstage/plugin-stack-overflow';
 import { searchResultCustomList } from './SearchResultCustomList';
+import { refreshLinkClickTracking } from '@snowplow/browser-plugin-link-click-tracking';
 
 const useStyles = makeStyles((theme: Theme) => ({
   search: {
@@ -57,7 +58,7 @@ const SearchPage = () => {
               <SearchBar className={classes.search} />
             </Paper>
           </Grid>
-          <Grid item xs={3}>
+          <Grid item xs={3} onClick={() => setTimeout(refreshLinkClickTracking, 250)}>
             <SearchType.Accordion
               name="Result Type"
               types={[

--- a/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/app/src/components/search/SearchPage.tsx
@@ -23,7 +23,6 @@ import {
 import { useApi } from '@backstage/core-plugin-api';
 import { StackOverflowIcon } from '@backstage/plugin-stack-overflow';
 import { searchResultCustomList } from './SearchResultCustomList';
-import { refreshLinkClickTracking } from '@snowplow/browser-plugin-link-click-tracking';
 
 const useStyles = makeStyles((theme: Theme) => ({
   search: {
@@ -58,7 +57,7 @@ const SearchPage = () => {
               <SearchBar className={classes.search} />
             </Paper>
           </Grid>
-          <Grid item xs={3} onClick={() => setTimeout(refreshLinkClickTracking, 250)}>
+          <Grid item xs={3}>
             <SearchType.Accordion
               name="Result Type"
               types={[

--- a/packages/app/src/components/search/SearchResultCustomList.tsx
+++ b/packages/app/src/components/search/SearchResultCustomList.tsx
@@ -7,12 +7,13 @@ import { CatalogSearchResultListItem } from '@backstage/plugin-catalog';
 import { StackOverflowSearchResultListItem, StackOverflowIcon } from '@backstage/plugin-stack-overflow';
 import { CatalogIcon, DocsIcon } from '@backstage/core-components';
 import { TechDocsSearchResultCustomListItem } from './TechDocsSearchResultCustomListItem';
+import { refreshLinkClickTracking } from '@snowplow/browser-plugin-link-click-tracking';
 
 const SearchResultCustomList = () => {
     return (
         <SearchResult>
             {({ results }) => (
-                <List>
+                <List onMouseOver={() => refreshLinkClickTracking()}>
                   {results.map(({ type, document, highlight, rank }) => {
                     switch (type) {
                       case 'software-catalog':

--- a/packages/app/src/components/search/SearchResultCustomList.tsx
+++ b/packages/app/src/components/search/SearchResultCustomList.tsx
@@ -13,7 +13,7 @@ const SearchResultCustomList = () => {
     return (
         <SearchResult>
             {({ results }) => (
-                <List onMouseOver={() => refreshLinkClickTracking()}>
+                <List onMouseEnter={() => refreshLinkClickTracking()}>
                   {results.map(({ type, document, highlight, rank }) => {
                     switch (type) {
                       case 'software-catalog':


### PR DESCRIPTION
Hi,

Extremely minimal changes here, but I wanted to run it past both of you.

I found introducing a slight delay via "setTimeout" to be necessary for super consistent results with link tracking. Specifically with the location hook and expand button.

Also, initially I was tracking search result links with "useEffect" on the search bar value fields. It was working quite well, but missed changes to the results via filters and paging. I opted to simply call "refreshLinkClickTracking" when the result list fires onMouseOver. Maybe that's a tad heavy-handed? But it's working really well in my testing.

Thoughts?