### PR TITLE
Devx-77 Fix automated version bump

### DIFF
--- a/.github/scripts/set-release-name.js
+++ b/.github/scripts/set-release-name.js
@@ -16,48 +16,20 @@ async function getLatestRelease() {
   return json
 }
 
-async function getLatestPreRelease() {
-  const response = await fetch('https://api.github.com/repos/backstage/backstage/releases')
-  const json = await response.json();
-
-  const preReleasesOnly = json.filter(release => {
-    return release.prerelease === true
-  })
-  
-  const latestPreRelease = preReleasesOnly.sort((a,b) => {return new Date(b.published_at) - new Date(a.published_at)})[0];
-
-  return latestPreRelease
-}
-
 async function main() {
   
   // Get the current Backstage version from the backstage.json file
   const backstageVersion = await getBackstageVersion()
   // Get the latest Backstage Release from the GitHub API
   const latestRelease = await getLatestRelease()
-  // Get the latest Backstage Pre-release from the GitHub API
-  const latestPreRelease = await getLatestPreRelease()
+  
 
   console.log(`Current Backstage version is: v${backstageVersion}`)
   console.log(`Latest Release version is: ${latestRelease.name}, published on: ${latestRelease.published_at}`)
-  console.log(`Latest Pre-release version is: ${latestPreRelease.name}, published on: ${latestPreRelease.published_at}`)
   console.log()
-
-  const latestReleaseDate = new Date(latestRelease.published_at).getTime()
-  const latestPreReleaseDate = new Date(latestPreRelease.published_at).getTime()
-  if (latestReleaseDate > latestPreReleaseDate){
-    console.log(`Latest Release is newer than latest Pre-release, using Latest Release name ${latestRelease.name}`)
-    console.log()
-
-    await fs.appendFile(process.env.GITHUB_OUTPUT, `release_version=${latestRelease.name.substring(1)}${EOL}`);
-  }
-  else {
-    console.log(`Latest Release is older than latest Pre-release, using Latest Pre-release name ${latestPreRelease.name}`)
-    console.log()
-
-    await fs.appendFile(process.env.GITHUB_OUTPUT, `release_version=${latestPreRelease.name.substring(1)}${EOL}`);
-  }
-
+ 
+  await fs.appendFile(process.env.GITHUB_OUTPUT, `release_version=${latestRelease.name.substring(1)}${EOL}`);
+  
   await fs.appendFile(process.env.GITHUB_OUTPUT, `current_version=${backstageVersion}${EOL}`);
 }
 

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -4,17 +4,6 @@
 name: 'Version Bump'
 on:
   workflow_dispatch:
-    inputs:
-      # By default the bump command will upgrade @backstage packages to the latest main release line which is released monthly. 
-      # Alternatively, use the 'next' release line which releases weekly by using the --release next option.  
-      release_line:
-        description: 'Release Line'
-        required: true
-        default: main
-        type: choice
-        options:
-        - next
-        - main
   
   # Run at midnight every Monday
   schedule:
@@ -24,6 +13,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+
 jobs:
   version-bump:
     runs-on: ubuntu-latest
@@ -31,7 +21,7 @@ jobs:
       - name: 'Checkout backstage'
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       # Beginning of yarn setup
       - name: Setup Node
@@ -39,16 +29,19 @@ jobs:
         with:
           node-version: 18.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
+
       - name: cache all node_modules
         id: cache-modules
         uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock', '**/package.json') }}
+
       - name: find location of global yarn cache
         id: yarn-cache
         if: steps.cache-modules.outputs.cache-hit != 'true'
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
       - name: cache global yarn cache
         uses: actions/cache@v3
         if: steps.cache-modules.outputs.cache-hit != 'true'
@@ -57,6 +50,7 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
       - name: yarn install
         run: yarn install --frozen-lockfile
       # End of yarn setup
@@ -64,22 +58,41 @@ jobs:
       - name: 'Set release name'
         id: set_release_name
         run: node ./.github/scripts/set-release-name.js
+
       - name: 'Configure git'
         # From https://github.com/orgs/community/discussions/26560#discussioncomment-3531273
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-      - name: 'Create topic branch'
-        run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          BRANCH=$(git branch --list topic/v${{ steps.set_release_name.outputs.release_version }})
+
+      - name: 'Does branch exist'
+        id: branch_exists
+        run: |
+          BRANCH=$(git branch -r --list origin/topic/v${{ steps.set_release_name.outputs.release_version }})
+          echo "Existing branch is: $BRANCH"
           if [ ! -z "$BRANCH" ]; then
-              git branch -D topic/v${{ steps.set_release_name.outputs.release_version }}
+              echo "Branch exists"
+              echo "BRANCH_EXISTS=1" >> $GITHUB_OUTPUT
+          else
+            echo "branch does NOT exist"
+            echo "BRANCH_EXISTS=0" >> $GITHUB_OUTPUT
           fi
+          
+         
+      - name: 'Create branch'
+        id: branch_created
+        if: ${{ steps.branch_exists.outputs.BRANCH_EXISTS == 0 }}  
+        run: |
           git checkout -b topic/v${{ steps.set_release_name.outputs.release_version }}
-      - name: Run backstage-cli versions:bump --release ${{ inputs.release_line || 'main' }} command
-        run: yarn backstage-cli versions:bump --release ${{ inputs.release_line || 'main' }}
+          echo "CREATED_BRANCH=1" >> $GITHUB_OUTPUT
+
+      - name: 'Run backstage-cli versions command'
+        if: ${{ steps.branch_created.outputs.CREATED_BRANCH == 1 }}  
+        run: yarn backstage-cli versions:bump --release 'main'
+
       - name: 'Check for changes'
+        if: ${{ steps.branch_created.outputs.CREATED_BRANCH == 1 }}  
         id: check_for_changes
         run: |
           CHANGES=$(git status --porcelain)
@@ -90,6 +103,7 @@ jobs:
               echo "Has changes"
               echo "HAS_CHANGES=1" >> $GITHUB_OUTPUT
           fi
+
       - name: 'Commit changes'
         if: ${{ steps.check_for_changes.outputs.HAS_CHANGES == 1 }}
         run: |
@@ -97,6 +111,8 @@ jobs:
           git add -A -- :!.npmrc
           git commit -m "v${{ steps.set_release_name.outputs.release_version }} version bump"
           git push origin topic/v${{ steps.set_release_name.outputs.release_version }}
+
+     
       - name: 'Create Pull Request'
         if: ${{ steps.check_for_changes.outputs.HAS_CHANGES == 1 }}
         uses: actions/github-script@v7
@@ -121,3 +137,4 @@ jobs:
                 ' '
               ].join('\n')
             });
+      


### PR DESCRIPTION
The version-bump GitHub action is creating pull requests named after the ‘next’ version bumps, even though it is only doing the ‘main’ line bump.

Changes made:

* Removed the 'main' and 'next' options for the manual workflow run. Manual will always do a main update, as we don't do next versions
* Removed the code in the script that would get the 'next' release. We don't use it, and was causing the branch to be named wrong
* Changed how branch is created. Previously, if a branch was detected it deleted the branch and created a new one.
  * It now skips the steps instead.

