### PR TITLE
Copy change to templatepage title

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -124,7 +124,13 @@ const routes = (
 				<Mermaid config={{ theme: 'forest', themeVariables: { lineColor: '#000000' } }} />
 			</TechDocsAddons>
 		</Route>
-		<Route path="/create" element={<ScaffolderPage/>}/>
+		<Route path="/create" element={<ScaffolderPage
+				headerOptions={{
+					title: "DevHub quick starts", 
+					subtitle: "Create or modify bcgov GitHub repositories with easy and fast templates for common tools and technologies"
+				}}
+			/>}
+		/>
 		<Route path="/api-docs" element={<ApiExplorerPage/>}/>
 		<Route
 			path="/tech-radar"


### PR DESCRIPTION
This branch has the title & subtitle copy change for the templates page.

The changes to the templates themselves are here: https://github.com/bcgov/devhub-templates

Here's what the new header looks like
![DevHub-template-title](https://github.com/bcgov/developer-portal/assets/103235538/3cd17288-9d2e-4f1d-88ed-be88cc761906)

I looked into changing the help / support text, but it doesn't seem possible currently. We can add our own links there via app-config, but the text itself appears hard coded in the component w/o an override option.
