### PR TITLE
Devx1314 better404

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -43,6 +43,7 @@ import HomePage from './components/home/HomePage';
 import { TocFix } from '@app/plugin-toc-fix2';
 import { TechdocExpandableToc } from '@app/plugin-expandable-toc';
 import {Mermaid} from "backstage-plugin-techdocs-addon-mermaid";
+import { Custom404Page } from './components/404/Custom404Page';
 
 const app = createApp({
 	apis,
@@ -93,6 +94,9 @@ const app = createApp({
 			),
 		},
 	],
+	components: { NotFoundErrorPage: () => (
+		<Custom404Page />
+	)},
 });
 
 const ExternalRedirect = ({ to }: { to: string }) => {
@@ -160,6 +164,8 @@ const routes = (
 		<Route path="/Design-System/About-the-Design-System" element={<Navigate to='/docs/default/component/bc-developer-guide/design-system/about-the-design-system/' />}/>
 		<Route path="/Data-and-APIs/BC-Government-API-Guidelines" element={<ExternalRedirect to='https://classic.developer.gov.bc.ca/Data-and-APIs/BC-Government-API-Guidelines' />}/>
 		<Route path="/BC-Government-API-Guidelines" element={<ExternalRedirect to='https://classic.developer.gov.bc.ca/BC-Government-API-Guidelines' />}/>
+
+		<Route path="*" element={<Custom404Page />} /> 
 	</FlatRoutes>
 );
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -164,8 +164,6 @@ const routes = (
 		<Route path="/Design-System/About-the-Design-System" element={<Navigate to='/docs/default/component/bc-developer-guide/design-system/about-the-design-system/' />}/>
 		<Route path="/Data-and-APIs/BC-Government-API-Guidelines" element={<ExternalRedirect to='https://classic.developer.gov.bc.ca/Data-and-APIs/BC-Government-API-Guidelines' />}/>
 		<Route path="/BC-Government-API-Guidelines" element={<ExternalRedirect to='https://classic.developer.gov.bc.ca/BC-Government-API-Guidelines' />}/>
-
-		<Route path="*" element={<Custom404Page />} /> 
 	</FlatRoutes>
 );
 

--- a/packages/app/src/components/404/Custom404Page.tsx
+++ b/packages/app/src/components/404/Custom404Page.tsx
@@ -33,6 +33,10 @@ const useStyles = makeStyles(theme => ({
 
 const rootRouteRef = searchPlugin.routes.root;
 
+const rmTrailingSlash = (str: string) => {
+  return str.replace(/\/+$/, '');
+}
+
 export function Custom404Page() {
   const classes = useStyles();
   const location = useLocation();
@@ -41,7 +45,7 @@ export function Custom404Page() {
   const searchBarRef = useRef<HTMLInputElement | null>(null);
 
   // grab the url slug
-  const pagePath = location.pathname.split('/').pop();
+  const pagePath = rmTrailingSlash(location.pathname).split('/').pop();
 
   const preFiltered = {
     term: pagePath?.replaceAll('-', ' ')?.replaceAll('_', ' ') ?? '',

--- a/packages/app/src/components/404/Custom404Page.tsx
+++ b/packages/app/src/components/404/Custom404Page.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { Box, Button, Divider, Grid, Theme, Typography, makeStyles, useTheme } from '@material-ui/core';
+import { Box, Button, Divider, Grid, Typography, makeStyles } from '@material-ui/core';
 import { Content, Page } from '@backstage/core-components';
 import { SearchBar, SearchContextProvider, SearchPagination } from '@backstage/plugin-search-react';
 import { searchPlugin } from '@backstage/plugin-search';
@@ -21,6 +21,9 @@ const useStyles = makeStyles(theme => ({
   input: {
     flex: 1,
   },
+  link: {
+    color: theme.palette.primary.main,
+  },
   button: {
     '&:hover': {
       background: 'none',
@@ -32,7 +35,6 @@ const rootRouteRef = searchPlugin.routes.root;
 
 export function Custom404Page() {
   const classes = useStyles();
-  const theme: Theme = useTheme();
   const location = useLocation();
   const navigate = useNavigate();
   const searchRootRoute = useRouteRef(rootRouteRef)();
@@ -54,7 +56,7 @@ export function Custom404Page() {
   // This handler is called when "enter" is pressed
   const handleSearchBarSubmit = useCallback(() => {
     // Using ref to get the current field value without waiting for a query debounce
-    const query = preFiltered.term;
+    const query = searchBarRef.current?.value ?? '';
     navigate(`${searchRootRoute}?query=${query}`);
   }, [navigate, searchBarRef]);
 
@@ -66,7 +68,11 @@ export function Custom404Page() {
             <Typography variant="h1">Page not found</Typography>
             <Divider orientation="horizontal" variant="middle" />
             <Box pt={3}>
-              <Typography variant="h6"><Link style={{color: theme.palette.primary.main}} to="#" onClick={() => navigate(-1)}>Go back</Link> or <Link style={{color: theme.palette.primary.main}} to={`https://classic.developer.gov.bc.ca/?q=${preFiltered.term}`}>Search Classic DevHub</Link> - please <Link style={{color: theme.palette.primary.main}} to="https://github.com/bcgov/developer-portal/issues">contact support</Link> if you think this is a bug</Typography>
+              <Typography variant="h6">
+                <Link className={classes.link} to="#" onClick={() => navigate(-1)}>Go back</Link> or&nbsp;
+                <Link className={classes.link} to={`https://classic.developer.gov.bc.ca/?q=${preFiltered.term}`}>Search Classic DevHub</Link> - please&nbsp;
+                <Link className={classes.link} to="https://github.com/bcgov/developer-portal/issues">contact support</Link> if you think this is a bug
+              </Typography>
             </Box>
 
             <Box pt={3} className={classes.title}>

--- a/packages/app/src/components/404/Custom404Page.tsx
+++ b/packages/app/src/components/404/Custom404Page.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles(theme => ({
 const rootRouteRef = searchPlugin.routes.root;
 
 const rmTrailingSlash = (str: string) => {
-  return str.replace(/\/+$/, '');
+  return str.replace(/\/{1,5}$/, '');
 }
 
 export function Custom404Page() {

--- a/packages/app/src/components/404/Custom404Page.tsx
+++ b/packages/app/src/components/404/Custom404Page.tsx
@@ -73,9 +73,7 @@ export function Custom404Page() {
             <Divider orientation="horizontal" variant="middle" />
             <Box pt={3}>
               <Typography variant="h6">
-                <Link className={classes.link} to="#" onClick={() => navigate(-1)}>Go back</Link> or&nbsp;
-                <Link className={classes.link} to={`https://classic.developer.gov.bc.ca/?q=${preFiltered.term}`}>Search Classic DevHub</Link> - please&nbsp;
-                <Link className={classes.link} to="https://github.com/bcgov/developer-portal/issues">contact support</Link> if you think this is a bug
+                Please <Link className={classes.link} to="https://github.com/bcgov/developer-portal/issues">contact support</Link> if you think this is a bug
               </Typography>
             </Box>
 
@@ -112,7 +110,11 @@ export function Custom404Page() {
                 {searchResultCustomList}
               </Grid>
             </Grid>
-
+            <Box pt={3}>
+              <Typography variant="h6">
+                  <Link className={classes.link} to={`https://classic.developer.gov.bc.ca/?q=${preFiltered.term}`}>Search Classic DevHub</Link>
+              </Typography>
+            </Box>
           </Box>
         </SearchContextProvider>
       </Content>

--- a/packages/app/src/components/404/Custom404Page.tsx
+++ b/packages/app/src/components/404/Custom404Page.tsx
@@ -1,0 +1,111 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { Box, Button, Divider, Grid, Theme, Typography, makeStyles, useTheme } from '@material-ui/core';
+import { Content, Page } from '@backstage/core-components';
+import { SearchBar, SearchContextProvider, SearchPagination } from '@backstage/plugin-search-react';
+import { searchPlugin } from '@backstage/plugin-search';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { searchResultCustomList } from '../search/SearchResultCustomList';
+import { useRouteRef } from '@backstage/core-plugin-api';
+import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
+
+const useStyles = makeStyles(theme => ({
+  title: {
+    gap: theme.spacing(1),
+    display: 'grid',
+    alignItems: 'center',
+    gridTemplateColumns: '1fr auto',
+    '&> button': {
+      marginTop: theme.spacing(1),
+    },
+  },
+  input: {
+    flex: 1,
+  },
+  button: {
+    '&:hover': {
+      background: 'none',
+    },
+  },
+}));
+
+const rootRouteRef = searchPlugin.routes.root;
+
+export function Custom404Page() {
+  const classes = useStyles();
+  const theme: Theme = useTheme();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const searchRootRoute = useRouteRef(rootRouteRef)();
+  const searchBarRef = useRef<HTMLInputElement | null>(null);
+
+  // grab the url slug
+  const pagePath = location.pathname.split('/').pop();
+
+  const preFiltered = {
+    term: pagePath?.replaceAll('-', ' ')?.replaceAll('_', ' ') ?? '',
+    types: [],
+    filters: {},
+  };
+
+  useEffect(() => {
+    searchBarRef?.current?.focus();
+  });
+
+  // This handler is called when "enter" is pressed
+  const handleSearchBarSubmit = useCallback(() => {
+    // Using ref to get the current field value without waiting for a query debounce
+    const query = preFiltered.term;
+    navigate(`${searchRootRoute}?query=${query}`);
+  }, [navigate, searchBarRef]);
+
+  return (
+    <Page themeId="home">
+      <Content>
+        <SearchContextProvider initialState={preFiltered}>
+          <Box padding="calc(2.1rem - 24px) 9%">
+            <Typography variant="h1">Page not found</Typography>
+            <Divider orientation="horizontal" variant="middle" />
+            <Box pt={3}>
+              <Typography variant="h6"><Link style={{color: theme.palette.primary.main}} to="#" onClick={() => navigate(-1)}>Go back</Link> or <Link style={{color: theme.palette.primary.main}} to={`https://classic.developer.gov.bc.ca/?q=${preFiltered.term}`}>Search Classic DevHub</Link> - please <Link style={{color: theme.palette.primary.main}} to="https://github.com/bcgov/developer-portal/issues">contact support</Link> if you think this is a bug</Typography>
+            </Box>
+
+            <Box pt={3} className={classes.title}>
+              <SearchBar
+                className={classes.input}
+                inputProps={{ ref: searchBarRef }}
+                onSubmit={handleSearchBarSubmit}
+              />
+            </Box>
+
+            <Grid
+              container
+              justifyContent="space-between"
+              alignItems="center"
+            >
+              <Grid item>
+                <SearchPagination />
+              </Grid>
+              <Grid item>
+                <Button
+                  className={classes.button}
+                  color="primary"
+                  endIcon={<ArrowForwardIcon />}
+                  onClick={handleSearchBarSubmit}
+                  disableRipple
+                >
+                  View Full Results
+                </Button>
+              </Grid>
+            </Grid>
+            <Grid container direction="row">
+              <Grid item xs={9}>
+                {searchResultCustomList}
+              </Grid>
+            </Grid>
+
+          </Box>
+        </SearchContextProvider>
+      </Content>
+    </Page>
+  );
+}

--- a/packages/app/src/components/404/Custom404Page.tsx
+++ b/packages/app/src/components/404/Custom404Page.tsx
@@ -71,13 +71,8 @@ export function Custom404Page() {
           <Box padding="calc(2.1rem - 24px) 9%">
             <Typography variant="h1">Page not found</Typography>
             <Divider orientation="horizontal" variant="middle" />
-            <Box pt={3}>
-              <Typography variant="h6">
-                Please <Link className={classes.link} to="https://github.com/bcgov/developer-portal/issues">contact support</Link> if you think this is a bug
-              </Typography>
-            </Box>
 
-            <Box pt={3} className={classes.title}>
+            <Box pt={5} className={classes.title}>
               <SearchBar
                 className={classes.input}
                 inputProps={{ ref: searchBarRef }}
@@ -110,9 +105,10 @@ export function Custom404Page() {
                 {searchResultCustomList}
               </Grid>
             </Grid>
-            <Box pt={3}>
+            <Box pt={5}>
               <Typography variant="h6">
                   <Link className={classes.link} to={`https://classic.developer.gov.bc.ca/?q=${preFiltered.term}`}>Search Classic DevHub</Link>
+                  &nbsp;- please <Link className={classes.link} to="https://github.com/bcgov/developer-portal/issues">contact support</Link> if you think this is a bug
               </Typography>
             </Box>
           </Box>


### PR DESCRIPTION
I've added a custom 404 page to (largely) replace the default "dropped the mic" page.

It uses the url slug to search DevHub, and also provides a link to search classic DevHub with the same search term.

For example, someone trying to visit "developer.gov.bc.ca/Mobile-Starter-Kit-Overview" would land on the new 404 page with DevHub search results for "Mobile Starter Kit Overview". There would also be a link to search Classic DevHub for "Mobile Starter Kit Overview"

One caveat is that this 404 catches requests without a matching route, however our docs route matches on `/docs/:namespace/:kind/:name/*`
So any page request that fits that format will **not** get caught by the new 404 page. If the corresponding docs page doesn't exist then the user gets the old "dropped the mic" page.

It should be possible to write some logic that detects if the docs page exists and then routes to the TechDocs page or 404 accordingly.

A preview build is deploying now. It should be finished in around an hour.
https://f5ff48-developer-portal-dev-dprepo-pr-118-f5ff48-dev.apps.silver.devops.gov.bc.ca

btw, these preview branches won't have the same search results as production.