### PR TITLE
OnThisPage cut off fix

### DIFF
--- a/plugins/techdoc-expandable-toc/src/addons/ExpandableToc.tsx
+++ b/plugins/techdoc-expandable-toc/src/addons/ExpandableToc.tsx
@@ -50,12 +50,12 @@ export const ExpandableTocAddon = () => {
         { defaultValue },
     );
 
-    const tocList = useShadowRootElements<HTMLLabelElement>([TOC_LIST]);
+    const tocList = useShadowRootElements<HTMLUListElement>([TOC_LIST]);
     const isEmpty = (tocList.length === 0);
 
     useEffect(() => {
     tocList.forEach(match => {
-        match.hidden = !expanded?.expandToc;
+      match.style.display = expanded?.expandToc ? 'block' : 'none';
     });
     }, [expanded, tocList]);
 


### PR DESCRIPTION
"On This Page" header was being cutoff slightly on some docs pages when collapsed.

Switched from hidden property to display: none