### PR TITLE
Devx1275 copy codeblock bug

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -20,7 +20,7 @@ import {
 	TechDocsReaderPage,
 } from '@backstage/plugin-techdocs';
 import {TechDocsAddons} from '@backstage/plugin-techdocs-react';
-import {ExpandableNavigation, ReportIssue} from '@backstage/plugin-techdocs-module-addons-contrib';
+import { /*ExpandableNavigation*/ ReportIssue} from '@backstage/plugin-techdocs-module-addons-contrib';
 import {UserSettingsPage} from '@backstage/plugin-user-settings';
 import {apis} from './apis';
 import {entityPage} from './components/catalog/EntityPage';
@@ -129,7 +129,7 @@ const routes = (
 			<TechDocsAddons>
 				<ReportIssue/>
 				<TocFix/>
-				<ExpandableNavigation />
+				{/* <ExpandableNavigation /> */}
 				<TechdocExpandableToc />
 				<Mermaid config={{ theme: 'forest', themeVariables: { lineColor: '#000000' } }} />
 			</TechDocsAddons>

--- a/plugins/techdoc-expandable-toc/src/addons/ExpandableToc.tsx
+++ b/plugins/techdoc-expandable-toc/src/addons/ExpandableToc.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useLocalStorageValue } from '@react-hookz/web';
-import { Button, withStyles } from '@material-ui/core';
+import { makeStyles, withStyles } from '@material-ui/core';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
@@ -11,15 +11,15 @@ const TOC_LIST = 'ul[data-md-component="toc"]';
 const EXPANDABLE_TOC_LOCAL_STORAGE =
   '@backstage/techdocs-addons/toc-expanded';
 
-const StyledButton = withStyles({
-  root: {
+const useStyles = makeStyles({
+  span: {
     position: 'absolute',
     left: '220px',
     top: '19px',
     padding: 0,
     minWidth: 0,
   },
-})(Button);
+});
 
 const CollapsedIcon = withStyles({
   root: {
@@ -43,6 +43,7 @@ type expandableTocLocalStorage = {
  * Show expand/collapse button next to ToC header
  */
 export const ExpandableTocAddon = () => {
+    const classes = useStyles();
     const defaultValue = { expandToc: false };
     const { value: expanded, set: setExpanded } =
     useLocalStorageValue<expandableTocLocalStorage>(
@@ -68,13 +69,13 @@ export const ExpandableTocAddon = () => {
     return (
         <>
             { !isEmpty ? (
-                <StyledButton
-                    size="small"
+                <span
+                    className={classes.span}
                     onClick={handleState}
                     aria-label={expanded?.expandToc ? 'collapse-toc' : 'expand-toc'}
                 >
                     {expanded?.expandToc ? <ExpandedIcon /> : <CollapsedIcon />}
-                </StyledButton>
+                </span>
             ) : null}
         </>
     );

--- a/plugins/techdoc-expandable-toc/src/addons/ExpandableToc.tsx
+++ b/plugins/techdoc-expandable-toc/src/addons/ExpandableToc.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import { useLocalStorageValue } from '@react-hookz/web';
 import { makeStyles, withStyles } from '@material-ui/core';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
 import { useShadowRootElements } from '@backstage/plugin-techdocs-react';
 
@@ -21,19 +20,13 @@ const useStyles = makeStyles({
   },
 });
 
-const CollapsedIcon = withStyles({
-  root: {
-    height: '20px',
-    width: '20px',
-  },
-})(ChevronRightIcon);
-
 const ExpandedIcon = withStyles({
   root: {
     height: '20px',
     width: '20px',
+    transition: 'transform .25s'
   },
-})(ExpandMoreIcon);
+})(ChevronRightIcon);
 
 type expandableTocLocalStorage = {
   expandToc: boolean;
@@ -74,7 +67,10 @@ export const ExpandableTocAddon = () => {
                     onClick={handleState}
                     aria-label={expanded?.expandToc ? 'collapse-toc' : 'expand-toc'}
                 >
-                    {expanded?.expandToc ? <ExpandedIcon /> : <CollapsedIcon />}
+                    <ExpandedIcon 
+                      style={{ transform: expanded?.expandToc ? 'rotate(90deg)' : 'rotate(0)' }} 
+                      cursor='pointer'
+                    />
                 </span>
             ) : null}
         </>

--- a/plugins/techdoc-expandable-toc/src/addons/ExpandableToc.tsx
+++ b/plugins/techdoc-expandable-toc/src/addons/ExpandableToc.tsx
@@ -65,6 +65,7 @@ export const ExpandableTocAddon = () => {
                 <span
                     className={classes.span}
                     onClick={handleState}
+                    onKeyDown={handleState}
                     aria-label={expanded?.expandToc ? 'collapse-toc' : 'expand-toc'}
                 >
                     <ExpandedIcon 


### PR DESCRIPTION
I was looking into this issue and found this Backstage bug report: https://github.com/backstage/backstage/issues/20552

The gist of it is that including the ExpandableNavigation TechDocs addon can result in the behaviour we're seeing.

I verified that removing this addon, and our Expandable Table of Contents addon **does** fix the issue.

I tried to isolate the specific cause, and found that any sidebar addon (primary or secondary) using an mui button will result in these wonky code blocks....

Even something outlandishly simple:
```
import React from 'react';
import { Button } from '@material-ui/core';

export const myTechDocsAddon = () => {
  return (
    <Button />
  );
};
```
Maybe there's some CSS magic that might be a better solution, but my approach here was to disable the ExpandableNavigation addon, and switch the Expandable Table of Contents addon to use a clickable icon (which is what the vanilla TechDocs nav uses anyway).

Since ExpandableNavigation is part of `plugin-techdocs-module-addons-contrib` we would have to submit a PR to get that fixed. As I recall, the addon was never directly requested and I enabled it as a QoL improvement to minimize the nav "screen real estate". In other words, I don't think turning it off will be a deal-breaker, and imo is preferable to the code blocks issue.

Curious to hear everyone's take.