### PR TITLE
Devx1374 clipped On This Page

### DIFF
--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -215,12 +215,12 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
         </SidebarScrollWrapper> */}
       </SidebarGroup>
       <SidebarSpace />
-      <SidebarDivider />
       <SidebarGroup
         label="Offsite Links"
       >
         <SidebarItem icon={LaunchIcon} to="https://classic.developer.gov.bc.ca" text="Classic DevHub" />
       </SidebarGroup>
+      <SidebarDivider />
       <SidebarGroup
         label="Settings"
         icon={<UserSettingsSignInAvatar />}

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -215,12 +215,12 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
         </SidebarScrollWrapper> */}
       </SidebarGroup>
       <SidebarSpace />
+      <SidebarDivider />
       <SidebarGroup
         label="Offsite Links"
       >
         <SidebarItem icon={LaunchIcon} to="https://classic.developer.gov.bc.ca" text="Classic DevHub" />
       </SidebarGroup>
-      <SidebarDivider />
       <SidebarGroup
         label="Settings"
         icon={<UserSettingsSignInAvatar />}

--- a/plugins/techdoc-expandable-toc/src/addons/ExpandableToc.tsx
+++ b/plugins/techdoc-expandable-toc/src/addons/ExpandableToc.tsx
@@ -6,7 +6,7 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
 import { useShadowRootElements } from '@backstage/plugin-techdocs-react';
 
-const TOC_LIST = 'ul[data-md-component="toc"]';
+const TOC_LIST = 'ul[data-md-component="toc"]>li';
 
 const EXPANDABLE_TOC_LOCAL_STORAGE =
   '@backstage/techdocs-addons/toc-expanded';
@@ -50,13 +50,13 @@ export const ExpandableTocAddon = () => {
         { defaultValue },
     );
 
-    const tocList = useShadowRootElements<HTMLUListElement>([TOC_LIST]);
+    const tocList = useShadowRootElements<HTMLLIElement>([TOC_LIST]);
     const isEmpty = (tocList.length === 0);
 
     useEffect(() => {
-    tocList.forEach(match => {
-      match.style.display = expanded?.expandToc ? 'block' : 'none';
-    });
+      tocList.forEach(match => {
+        match.style.display = expanded?.expandToc ? 'block' : 'none';
+      });
     }, [expanded, tocList]);
 
     const handleState = () => {
@@ -75,7 +75,7 @@ export const ExpandableTocAddon = () => {
                 >
                     {expanded?.expandToc ? <ExpandedIcon /> : <CollapsedIcon />}
                 </StyledButton>
-            ) : null}
+            ) : null }
         </>
     );
 };


### PR DESCRIPTION
Initially, the "On This Page" collapse button was toggling the display property for the whole ul element. For this issue I modified the behaviour so that it's now the child li elements being toggled on/off.

This issue is a little strange in that I was never able to reproduce it locally, but I tested these changes in a preview branch and found the text was no longed clipped in my browser (I tried Chrome, FireFox, and Safari).