### PR TITLE
Changing sidebar divider position to match footer

### DIFF
--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -215,12 +215,12 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
         </SidebarScrollWrapper> */}
       </SidebarGroup>
       <SidebarSpace />
-      <SidebarDivider />
       <SidebarGroup
         label="Offsite Links"
       >
         <SidebarItem icon={LaunchIcon} to="https://classic.developer.gov.bc.ca" text="Classic DevHub" />
       </SidebarGroup>
+      <SidebarDivider />
       <SidebarGroup
         label="Settings"
         icon={<UserSettingsSignInAvatar />}


### PR DESCRIPTION
Adding the Classic DevHub button moved the sidebar divider up so it no longer aligned with the bottom of the page. I moved the divider back down to the original position.

![DevHubDivider](https://github.com/bcgov/developer-portal/assets/103235538/dc8baba3-a856-45ef-9474-4f486ce69515)
