### PR TITLE
Disable inner scroll bars on docs nav bars

### DIFF
--- a/plugins/toc-fix2/src/addons/TocFixer.tsx
+++ b/plugins/toc-fix2/src/addons/TocFixer.tsx
@@ -22,6 +22,7 @@ export const TocFixer = () => {
 	// to test in browser, something like this can be used: document.querySelector("[data-testid='techdocs-native-shadowroot']").shadowRoot.querySelectorAll('div[data-md-type="toc"] a[href*="on-this-page"]')
 	const onThisPageHeadingInToc = useShadowRootElements<HTMLImageElement>(['div[data-md-type="toc"] a[href*="on-this-page"]'] );
 	const tocHeading = useShadowRootElements<HTMLLabelElement>(['label[for="__toc"]']);
+	const sidebarScrollWrap = useShadowRootElements<HTMLDivElement>(['div[class=md-sidebar__scrollwrap]']);
 
 	useEffect(() => {
 		onThisPageHeading.forEach(match => {
@@ -49,6 +50,12 @@ export const TocFixer = () => {
 			match.textContent = 'On this page';
 		});
 	}, [tocHeading]);
+
+	useEffect(() => {
+		sidebarScrollWrap.forEach(match => {
+			match.style.overflowY = 'hidden';
+		});
+	}, [sidebarScrollWrap]);
 
 	// Nothing to render directly, so we can just return null.
 	return null;


### PR DESCRIPTION
Disabled the inner scroll bars for the Docs nav sidebars. They don't do anything and the visual distraction of the double scroll bars upsets users.

I added the fix to the TocFixer plugin since the issue only effects the techdocs sidebars.

Running here: https://f5ff48-developer-portal-dev-dprepo-pr-138-f5ff48-dev.apps.silver.devops.gov.bc.ca/

before:
![doublescroll_before](https://github.com/bcgov/developer-portal/assets/103235538/cc0153ef-2be7-4b11-8699-3e692f1763e8)

after:
![doublescroll_after](https://github.com/bcgov/developer-portal/assets/103235538/ce72b046-6554-4228-a470-4c6b797940d5)
