### PR TITLE
Snowplow analytics plugin

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -50,6 +50,7 @@
     "@material-ui/lab": "^4.0.0-alpha.61",
     "@material-ui/styles": "^4.11.5",
     "@snowplow/browser-plugin-link-click-tracking": "^3.15.0",
+    "@snowplow/browser-plugin-site-tracking": "^3.23.1",
     "@snowplow/browser-tracker": "^3.15.0",
     "backstage-plugin-techdocs-addon-mermaid": "^0.11.0",
     "history": "^5.0.0",

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -7,7 +7,9 @@ import {
   AnyApiFactory,
   configApiRef,
   createApiFactory,
+  analyticsApiRef,
 } from '@backstage/core-plugin-api';
+import { SnowplowAnalytics } from '@internal/plugin-analytics-module-snowplow'
 
 export const apis: AnyApiFactory[] = [
   createApiFactory({
@@ -16,4 +18,9 @@ export const apis: AnyApiFactory[] = [
     factory: ({ configApi }) => ScmIntegrationsApi.fromConfig(configApi),
   }),
   ScmAuth.createDefaultApiFactory(),
+  createApiFactory({
+    api: analyticsApiRef,
+    deps: { configApi: configApiRef },
+    factory: ({ configApi }) => SnowplowAnalytics.fromConfig(configApi),
+  }),
 ];

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useEffect } from 'react';
+import React, { PropsWithChildren } from 'react';
 import { makeStyles } from '@material-ui/core';
 import HomeIcon from '@material-ui/icons/Home';
 // import CatalogIcon from '@material-ui/icons/LocalLibrary';
@@ -32,61 +32,6 @@ import {
 import MenuIcon from '@material-ui/icons/Menu';
 import SearchIcon from '@material-ui/icons/Search';
 import { CustomSearchModal } from '../search/CustomModal';
-
-import {useApi, configApiRef} from '@backstage/core-plugin-api';
-
-
-// snowplow analytics
-import {newTracker, trackPageView, enableActivityTracking} from '@snowplow/browser-tracker';
-import {
-    enableLinkClickTracking,
-    refreshLinkClickTracking,
-    LinkClickTrackingPlugin as linkTrackingPlugin
-} from '@snowplow/browser-plugin-link-click-tracking';
-import {useLocation} from "react-router-dom";
-
-
-const MyReactComponent = () => {
-    const config = useApi(configApiRef);
-
-    const location = useLocation();
-
-    // refresh link tracking whenever local navigation occurs
-    useEffect(() => {
-      setTimeout(refreshLinkClickTracking, 250);
-    }, [location]);
-
-    console.log("**********Setting up analytics (or not...)********");
-    console.log(`Config: ${JSON.stringify(config)}`);
-
-    if (config.getOptionalConfig('app.analytics') && config.getBoolean('app.analytics.snowplow.enabled')) {
-        console.log("**********Analytics enabled...********");
-
-        // const collectorUrl = "spm.apps.gov.bc.ca"
-        const collectorUrl = config.getString("app.analytics.snowplow.collectorUrl");
-
-        newTracker('rt', `${collectorUrl}`, {
-            appId: 'Snowplow_standalone_OCIO',
-            cookieLifetime: 86400 * 548,
-            platform: "web",
-            contexts: {
-                webPage: true
-            },
-            plugins: [linkTrackingPlugin()]
-        });
-
-        enableActivityTracking({
-            minimumVisitLength: 30,
-            heartbeatDelay: 30
-        });
-
-        enableLinkClickTracking();
-
-        trackPageView();
-    }
-    return null;
-}
-
 
 const storedTheme = localStorage.getItem('theme');
 
@@ -144,7 +89,6 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
 
   return (
   <SidebarPage>
-        <MyReactComponent/>
     <Sidebar>
       <SidebarLogo />
       <SidebarGroup label="Search" icon={<SearchIcon />} to="/search">

--- a/packages/app/src/components/search/SearchResultCustomList.tsx
+++ b/packages/app/src/components/search/SearchResultCustomList.tsx
@@ -7,13 +7,12 @@ import { CatalogSearchResultListItem } from '@backstage/plugin-catalog';
 import { StackOverflowSearchResultListItem, StackOverflowIcon } from '@backstage/plugin-stack-overflow';
 import { CatalogIcon, DocsIcon } from '@backstage/core-components';
 import { TechDocsSearchResultCustomListItem } from './TechDocsSearchResultCustomListItem';
-import { refreshLinkClickTracking } from '@snowplow/browser-plugin-link-click-tracking';
 
 const SearchResultCustomList = () => {
     return (
         <SearchResult>
             {({ results }) => (
-                <List onMouseEnter={() => refreshLinkClickTracking()}>
+                <List>
                   {results.map(({ type, document, highlight, rank }) => {
                     switch (type) {
                       case 'software-catalog':

--- a/packages/app/src/components/search/TechDocsSearchResultCustomListItem.tsx
+++ b/packages/app/src/components/search/TechDocsSearchResultCustomListItem.tsx
@@ -73,7 +73,7 @@ export const TechDocsSearchResultCustomListItem = (
 
   const LinkWrapper = ({ children }: PropsWithChildren<{}>) =>
     asLink ? (
-      <Link noTrack to={result.location}>
+      <Link to={result.location}>
         {children}
       </Link>
     ) : (

--- a/plugins/analytics-module-snowplow/config.d.ts
+++ b/plugins/analytics-module-snowplow/config.d.ts
@@ -7,11 +7,31 @@ export interface Config {
        * @visibility frontend
        */
         enabled: boolean;
-	  /**
-	   *
-	   * @visibility frontend
-	   */
-	  	collectorUrl: string;
+      /**
+       *
+       * @visibility frontend
+       */
+        appId: string;
+      /**
+       *
+       * @visibility frontend
+       */
+        collectorUrl: string;
+      /**
+       *
+       * @visibility frontend
+       */
+        trackerId: string;
+      /**
+       *
+       * @visibility frontend
+       */
+        cookieLifetime: number;
+      /**
+       *
+       * @visibility frontend
+       */
+        debounceTime: number;
       }
     }
   }

--- a/plugins/analytics-module-snowplow/config.d.ts
+++ b/plugins/analytics-module-snowplow/config.d.ts
@@ -11,27 +11,27 @@ export interface Config {
        *
        * @visibility frontend
        */
-        appId: string;
-      /**
-       *
-       * @visibility frontend
-       */
         collectorUrl: string;
       /**
        *
        * @visibility frontend
        */
-        trackerId: string;
+        appId?: string;
       /**
        *
        * @visibility frontend
        */
-        cookieLifetime: number;
+        trackerId?: string;
       /**
        *
        * @visibility frontend
        */
-        debounceTime: number;
+        cookieLifetime?: number;
+      /**
+       *
+       * @visibility frontend
+       */
+        debounceTime?: number;
       }
     }
   }

--- a/plugins/analytics-module-snowplow/src/apis/implementations/AnalyticsApi/SnowplowAnalytics.ts
+++ b/plugins/analytics-module-snowplow/src/apis/implementations/AnalyticsApi/SnowplowAnalytics.ts
@@ -1,0 +1,161 @@
+import { Config } from '@backstage/config';
+import {
+    AnalyticsApi,
+    AnalyticsEvent,
+} from '@backstage/core-plugin-api';
+import { newTracker, trackPageView, enableActivityTracking } from '@snowplow/browser-tracker';
+import { LinkClickTrackingPlugin, trackLinkClick } from '@snowplow/browser-plugin-link-click-tracking';
+import { SiteTrackingPlugin, trackSiteSearch } from '@snowplow/browser-plugin-site-tracking';
+
+export class SnowplowAnalytics implements AnalyticsApi {
+    private readonly enabled: boolean;
+    private readonly baseUrl: string;
+    private stack: AnalyticsEvent[];
+    private readonly debounceTime: number;
+    private cancelProc: NodeJS.Timeout | null;
+
+    private constructor(options: {
+        enabled: boolean,
+        baseUrl: string,
+        trackerId: string,
+        endpoint: string,
+        appId: string,
+        cookieLifetime: number,
+        debounceTime: number
+    }) {
+        const {
+            enabled,
+            baseUrl,
+            trackerId,
+            endpoint,
+            appId,
+            cookieLifetime,
+            debounceTime
+        } = options;
+
+        this.enabled = enabled;
+        this.baseUrl = baseUrl;
+        this.stack = [];
+        this.cancelProc = null;
+        this.debounceTime = debounceTime;
+        
+        // create the Snowplow tracker
+        console.log("**********Setting up analytics (or not...)********");
+        if (this.enabled) {
+            console.log("**********Analytics enabled...********");
+
+            newTracker(trackerId, endpoint, {
+                appId: appId,
+                cookieLifetime: cookieLifetime,
+                platform: "web",
+                contexts: {
+                    webPage: true
+                },
+                plugins: [LinkClickTrackingPlugin(), SiteTrackingPlugin()]
+            });
+
+            enableActivityTracking({
+                minimumVisitLength: 30,
+                heartbeatDelay: 30
+            });
+        }
+    }
+  
+    static fromConfig(config: Config): SnowplowAnalytics {
+        const enabled = config.getBoolean('app.analytics.snowplow.enabled');
+        const baseUrl = config.getString('app.baseUrl');
+        const endpoint = config.getString('app.analytics.snowplow.collectorUrl');
+        const appId = config.getOptionalString('app.analytics.snowplow.appId') || 'Snowplow_standalone_OCIO' ;
+        const trackerId = config.getOptionalString('app.analytics.snowplow.trackerId') || 'rt';
+        const cookieLifetime = config.getOptionalNumber('app.analytics.snowplow.cookieLifetime') ?? 86400 * 548;
+        const debounceTime = config.getOptionalNumber('app.analytics.snowplow.debounceTime') ?? 3000;
+
+        return new SnowplowAnalytics({
+            enabled,
+            baseUrl,
+            trackerId,
+            endpoint,
+            appId,
+            cookieLifetime,
+            debounceTime
+        });
+    }
+    
+    captureEvent(event: AnalyticsEvent): void {
+        if (this.enabled) {
+            switch (event.action) {
+                case "search":
+                    this.captureSearch(event);
+                    break;
+                case "navigate":
+                    this.trackPageView();
+                    break;
+                case "click":
+                case "discover":
+                    this.trackClick(event);
+                    break;
+            }
+        }
+    }
+
+    private trackPageView(): void {
+        trackPageView();
+    }
+
+    private trackClick(event: AnalyticsEvent): void {
+        let to: string = event.attributes?.to as string;
+        const isDomain = to.startsWith('https:');
+        const isMailto = to.startsWith('mailto:');
+
+        if (!isDomain && !isMailto) {
+            to = (to.startsWith('/'))? this.baseUrl + to : this.baseUrl + '/' + to;
+        }
+
+        trackLinkClick({ targetUrl: to, elementContent: event.subject });
+    }
+
+    private trackSearch(event: AnalyticsEvent): void {
+        trackSiteSearch({ terms: event.subject.split(" ") });
+    }
+
+    private captureSearch(event: AnalyticsEvent): void {
+        // push new events on the stack so the most recent is first
+        this.stack.unshift(event);
+
+        // cancel any pending process call
+        if (this.cancelProc) {
+            clearTimeout(this.cancelProc);
+        }
+
+        // process events, and reset stack once the debounceTime has elapsed
+        this.cancelProc = setTimeout(() => {
+            this.process(this.stack);
+            this.stack = [];
+            this.cancelProc = null;
+        }, this.debounceTime);
+    }
+
+    private process(events: AnalyticsEvent[]): void {
+        if (events) {
+            const sendList: AnalyticsEvent[] = [];
+
+             // walk event list starting with most recent
+            events.forEach(e => {
+                // skip substrings. ex. events that fired while the user was typing
+                if (!sendList.some( query => query.subject.startsWith(e.subject) )) {
+                    // if a previous event is a substring then swap. ex. the user backspaced off typos
+                    let index = sendList.findIndex( query => e.subject.startsWith(query.subject) );
+                    if (index >= 0) {
+                        sendList[index] = e;
+                    } else {
+                        sendList.unshift(e);
+                    }
+                }
+            });
+
+            // track pruned event list
+            sendList.forEach(this.trackSearch);
+        }
+    }
+
+}

--- a/plugins/analytics-module-snowplow/src/apis/implementations/AnalyticsApi/SnowplowAnalytics.ts
+++ b/plugins/analytics-module-snowplow/src/apis/implementations/AnalyticsApi/SnowplowAnalytics.ts
@@ -110,7 +110,8 @@ export class SnowplowAnalytics implements AnalyticsApi {
     }
 
     private trackSearch(event: AnalyticsEvent): void {
-        trackSiteSearch({ terms: event.subject.split(" ") });
+        // trim whitespace, split into non-empty terms
+        trackSiteSearch({ terms: event.subject.trim().split(" ").filter( t => t ) });
     }
 
     private captureSearch(event: AnalyticsEvent): void {

--- a/plugins/analytics-module-snowplow/src/apis/implementations/AnalyticsApi/SnowplowAnalytics.ts
+++ b/plugins/analytics-module-snowplow/src/apis/implementations/AnalyticsApi/SnowplowAnalytics.ts
@@ -98,7 +98,7 @@ export class SnowplowAnalytics implements AnalyticsApi {
 
     private trackClick(event: AnalyticsEvent): void {
         let to: string = event.attributes?.to as string ?? '';
-        const hasDomain = new RegExp(/(([A-Za-z0-9-])+\.)+[A-Za-z]/).test(to);
+        const hasDomain = new RegExp(/[A-Za-z0-9-]{1,63}\.[A-Za-z]{2,6}/).test(to);
         const isMailto = to.startsWith('mailto:');
 
         // add the baseUrl to relative path links (this is largely to remain consistent with previous analytics)

--- a/plugins/analytics-module-snowplow/src/apis/implementations/AnalyticsApi/SnowplowAnalytics.ts
+++ b/plugins/analytics-module-snowplow/src/apis/implementations/AnalyticsApi/SnowplowAnalytics.ts
@@ -38,10 +38,7 @@ export class SnowplowAnalytics implements AnalyticsApi {
         this.debounceTime = debounceTime;
         
         // create the Snowplow tracker
-        console.log("**********Setting up analytics (or not...)********");
         if (this.enabled) {
-            console.log("**********Analytics enabled...********");
-
             newTracker(trackerId, endpoint, {
                 appId: appId,
                 cookieLifetime: cookieLifetime,

--- a/plugins/analytics-module-snowplow/src/apis/implementations/AnalyticsApi/index.ts
+++ b/plugins/analytics-module-snowplow/src/apis/implementations/AnalyticsApi/index.ts
@@ -1,0 +1,1 @@
+export { SnowplowAnalytics } from './SnowplowAnalytics';

--- a/plugins/analytics-module-snowplow/src/index.ts
+++ b/plugins/analytics-module-snowplow/src/index.ts
@@ -1,1 +1,2 @@
-export {}
+export { analyticsModuleSnowplow } from './plugin';
+export * from './apis/implementations/AnalyticsApi';

--- a/plugins/analytics-module-snowplow/src/plugin.ts
+++ b/plugins/analytics-module-snowplow/src/plugin.ts
@@ -1,0 +1,5 @@
+import { createPlugin } from '@backstage/core-plugin-api';
+
+export const analyticsModuleSnowplow = createPlugin({
+  id: 'analytics-provider-snowplow',
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8820,12 +8820,31 @@
     "@snowplow/tracker-core" "3.23.0"
     tslib "^2.3.1"
 
+"@snowplow/browser-plugin-site-tracking@^3.23.1":
+  version "3.23.1"
+  resolved "https://registry.yarnpkg.com/@snowplow/browser-plugin-site-tracking/-/browser-plugin-site-tracking-3.23.1.tgz#4f666dd6ee409ed8302a4054bc072888bbab0b70"
+  integrity sha512-yi/NjHRowtUDRxSQJkqjW6tV5ChAIGez7f+jIzSpuOwoNd3IuepByZs/rzc8I2gnBw3HCO5qyy8vf7/5aS4yZw==
+  dependencies:
+    "@snowplow/browser-tracker-core" "3.23.1"
+    "@snowplow/tracker-core" "3.23.1"
+    tslib "^2.3.1"
+
 "@snowplow/browser-tracker-core@3.23.0":
   version "3.23.0"
   resolved "https://registry.yarnpkg.com/@snowplow/browser-tracker-core/-/browser-tracker-core-3.23.0.tgz#a849f6804e779c1b6539deb036c94d06db834fd9"
   integrity sha512-Lt0Mc2Z3NiWCskn8rfgAQ3SCAI16qeU/j7OB6PP1H9NM40hbUVvsg6txYn0JwY2hZEhD8C0H2fi16enbIpZkkw==
   dependencies:
     "@snowplow/tracker-core" "3.23.0"
+    sha1 "^1.1.1"
+    tslib "^2.3.1"
+    uuid "^3.4.0"
+
+"@snowplow/browser-tracker-core@3.23.1":
+  version "3.23.1"
+  resolved "https://registry.yarnpkg.com/@snowplow/browser-tracker-core/-/browser-tracker-core-3.23.1.tgz#e886f5de571a72cb57c8a71e05556a8a613aaca1"
+  integrity sha512-d2w8wjRX5NE/midFnzKlDaWjof6FgxS0d92OLu7FypSWL45uKrY1A13Qz6Quu+jrfWr4ox/9A2hIKQSDtmLeNg==
+  dependencies:
+    "@snowplow/tracker-core" "3.23.1"
     sha1 "^1.1.1"
     tslib "^2.3.1"
     uuid "^3.4.0"
@@ -8843,6 +8862,14 @@
   version "3.23.0"
   resolved "https://registry.yarnpkg.com/@snowplow/tracker-core/-/tracker-core-3.23.0.tgz#49fc6c679b9d81ac31a2bb911c6ccebc84f7473f"
   integrity sha512-q6Z7czCjyfzhnftnofWo+jaLf3jdmTO8yNze7WbJcnZBTQjO0iMjx1ffVieZ38zFOc+O6ANLv4roMfmgyohwiQ==
+  dependencies:
+    tslib "^2.3.1"
+    uuid "^3.4.0"
+
+"@snowplow/tracker-core@3.23.1":
+  version "3.23.1"
+  resolved "https://registry.yarnpkg.com/@snowplow/tracker-core/-/tracker-core-3.23.1.tgz#1543699518b5359aaabe72f962b45a6d03635d3b"
+  integrity sha512-EJJuRS2fI/XrrDaHSLnGfwLz+fweucwCeKF0cVNCVr5sm7kVw32DhHmFz1SCh2yMAN/9mGihyasTwRNONPuQSw==
   dependencies:
     tslib "^2.3.1"
     uuid "^3.4.0"
@@ -10414,9 +10441,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.13.1 || ^17.0.0", "@types/react@^16.13.1 || ^17.0.0 || ^18.0.0", "@types/react@^18":
-  version "18.3.2"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.2.tgz#462ae4904973bc212fa910424d901e3d137dbfcd"
-  integrity sha512-Btgg89dAnqD4vV7R3hlwOxgqobUQKgx3MmrQRi0yYbs/P0ym8XozIAlkqVilPqHQwXs4e9Tf63rrCgl58BcO4w==
+  version "18.3.3"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.3.tgz#9679020895318b0915d7a3ab004d92d33375c45f"
+  integrity sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -11295,6 +11322,7 @@ apg-lite@^1.0.3:
     "@material-ui/lab" "^4.0.0-alpha.61"
     "@material-ui/styles" "^4.11.5"
     "@snowplow/browser-plugin-link-click-tracking" "^3.15.0"
+    "@snowplow/browser-plugin-site-tracking" "^3.23.1"
     "@snowplow/browser-tracker" "^3.15.0"
     backstage-plugin-techdocs-addon-mermaid "^0.11.0"
     history "^5.0.0"
@@ -25156,20 +25184,6 @@ types-ramda@^0.30.0:
   integrity sha512-oVPw/KHB5M0Du0txTEKKM8xZOG9cZBRdCVXvwHYuNJUVkAiJ9oWyqkA+9Bj2gjMsHgkkhsYevobQBWs8I2/Xvw==
   dependencies:
     ts-toolbelt "^9.6.0"
-
-typescript-json-schema@^0.62.0:
-  version "0.62.0"
-  resolved "https://registry.yarnpkg.com/typescript-json-schema/-/typescript-json-schema-0.62.0.tgz#774b06b0c9d86d7f3580ea9136363a6eafae1470"
-  integrity sha512-qRO6pCgyjKJ230QYdOxDRpdQrBeeino4v5p2rYmSD72Jf4rD3O+cJcROv46sQukm46CLWoeusqvBgKpynEv25g==
-  dependencies:
-    "@types/json-schema" "^7.0.9"
-    "@types/node" "^16.9.2"
-    glob "^7.1.7"
-    path-equal "^1.2.5"
-    safe-stable-stringify "^2.2.0"
-    ts-node "^10.9.1"
-    typescript "~5.1.0"
-    yargs "^17.1.1"
 
 typescript-json-schema@^0.63.0:
   version "0.63.0"


### PR DESCRIPTION
### Snowplow search tracking + switching existing tracking over to the analytics plugin.

Search events fire whenever search results are returned, so we get an event for nearly every keystroke.
To get around this there's some logic to only track the most recent search event after a debounce time has elapsed.
This value can be configured via the app-config. Although, right now it's coming from a default value in the analytics module.

I attempted to keep the tracking consistent with the prior method, but I have observed some changes:

- It looks like some pageview events would fire twice occasionally. That's not happening with the backstage events, so I wouldn't be surprised if pageview counts go down as a result.
- Previously, links clicked from techdocs weren't being tracked. Now they are for internal links, but external links aren't generating an event.
- Some of the data attached to click events has changed. The builtin snowplow link tracking would include an array of class names from the clicked element. The Backstage events don't include this information, but do have content info like the button or link text. The Backstage events also include additional information such as entityRefs, routeRefs, pluginIds, but I didn't see anything wildly useful for our analytics.

previous click data
![snowplow_click_old](https://github.com/bcgov/developer-portal/assets/103235538/d23d397d-82cf-45b2-a5bf-8254ad4f77b0)

backstage click data
![snowplow_click_new](https://github.com/bcgov/developer-portal/assets/103235538/18d573f8-aea4-4522-bfe8-4ee9f0961d6f)

I've got a preview branch up here: https://f5ff48-developer-portal-dev-dprepo-pr-149-f5ff48-dev.apps.silver.devops.gov.bc.ca/
(I dropped the preview for the time being)