### PR TITLE
DEVX-1605 Update meta tags

### DIFF
--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -14,15 +14,15 @@
 	<meta property="og:site_name" content="DevHub" />
 	<meta property="og:title" content="B.C. government DevHub" />
 	<meta property="og:description" content="Access common technical documentation, community knowledge bases, code samples and APIs." />
-	<meta property="og:url" content="https://mvp.developer.gov.bc.ca/" />
-	<meta property="og:image" content="https://mvp.developer.gov.bc.ca/devhub-share.png" />
-	<meta property="og:image:secure_url" content="https://mvp.developer.gov.bc.ca/devhub-share.png" />
+	<meta property="og:url" content="https://developer.gov.bc.ca/" />
+	<meta property="og:image" content="https://developer.gov.bc.ca/devhub-share.png" />
+	<meta property="og:image:secure_url" content="https://developer.gov.bc.ca/devhub-share.png" />
 	<meta property="og:image:width" content="1200" />
 	<meta property="og:image:height" content="625" />
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:title" content="B.C. government DevHub" />
 	<meta name="twitter:description" content="Access common technical documentation, community knowledge bases, code samples and APIs." />
-	<meta name="twitter:image" content="https://mvp.developer.gov.bc.ca/devhub-share.png" />
+	<meta name="twitter:image" content="https://developer.gov.bc.ca/devhub-share.png" />
 	<!--
 	  manifest.json provides metadata used when your web app is installed on a
 	  user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/


### PR DESCRIPTION
The meta tags were using mvp.developer.gov.bc.ca. We have launched to developer.gov.bc.ca so the meta tags should be updated. 
