### PR TITLE
Update to latest version of backstage-plugin-techdocs-addon-mermaid

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -51,7 +51,7 @@
     "@snowplow/browser-plugin-link-click-tracking": "^3.15.0",
     "@snowplow/browser-plugin-site-tracking": "^3.23.1",
     "@snowplow/browser-tracker": "^3.15.0",
-    "backstage-plugin-techdocs-addon-mermaid": "^0.11.0",
+    "backstage-plugin-techdocs-addon-mermaid": "^0.13.0",
     "history": "^5.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10767,7 +10767,7 @@ apg-lite@^1.0.3:
     "@snowplow/browser-plugin-link-click-tracking" "^3.15.0"
     "@snowplow/browser-plugin-site-tracking" "^3.23.1"
     "@snowplow/browser-tracker" "^3.15.0"
-    backstage-plugin-techdocs-addon-mermaid "^0.11.0"
+    backstage-plugin-techdocs-addon-mermaid "^0.13.0"
     history "^5.0.0"
     react "^18.0.2"
     react-dom "^18.0.2"
@@ -11311,10 +11311,10 @@ backo2@^1.0.2:
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
   integrity sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==
 
-backstage-plugin-techdocs-addon-mermaid@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/backstage-plugin-techdocs-addon-mermaid/-/backstage-plugin-techdocs-addon-mermaid-0.11.0.tgz#89f72e0196ad9fe5dab92354be28de4f2a42670d"
-  integrity sha512-pJ1dY5zOspU3/9PQuEXMXv+wlFlQ6rQMUGPUyfp2dkWSP4BIsDVMrf9GfV6pht3x36aJegPoG99jaCclJDZgIg==
+backstage-plugin-techdocs-addon-mermaid@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/backstage-plugin-techdocs-addon-mermaid/-/backstage-plugin-techdocs-addon-mermaid-0.13.0.tgz#c9bf7fc4c720acbbe1fc7fe941a6823ef045abdc"
+  integrity sha512-j9/GU0dhuKBQnJk6vD8Al/F0G6Z2ix63wPGEU+3hFDqc/hw9IXxKmiyuhSt+bKpNGCbSC8OB1xySEk8l+EWSQg==
   dependencies:
     "@backstage/core-components" "^0.13.10"
     "@backstage/core-plugin-api" "^1.8.2"
@@ -11323,7 +11323,7 @@ backstage-plugin-techdocs-addon-mermaid@^0.11.0:
     "@material-ui/core" "^4.12.2"
     "@material-ui/icons" "^4.11.3"
     "@material-ui/lab" "4.0.0-alpha.61"
-    mermaid "^10.3.0"
+    mermaid "^10.9.1"
     react-use "^17.2.4"
 
 bail@^2.0.0:
@@ -19389,7 +19389,7 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-mermaid@^10.3.0:
+mermaid@^10.9.1:
   version "10.9.3"
   resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-10.9.3.tgz#90bc6f15c33dbe5d9507fed31592cc0d88fee9f7"
   integrity sha512-V80X1isSEvAewIL3xhmz/rVmc27CVljcsbWxkxlWJWY/1kQa4XOABqpDl2qQLGKzpKm6WbTfUEKImBlUfFYArw==


### PR DESCRIPTION
Update to latest version of the backstage-plugin-techdocs-addon-mermaid. It includes support for the mindmap diagram, which was added in version 0.13.0.


