### PR TITLE
Devx2006:  Wizards banner & sidebar

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -12,6 +12,8 @@ app:
     snowplow:
       enabled: true
       collectorUrl: https://spm.apps.gov.bc.ca
+  wizards:
+    enabled: false
 
 organization:
   name: BCDevExchange

--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -1,0 +1,11 @@
+export interface Config {
+  app: {
+    wizards?: {
+      /**
+       *
+       * @visibility frontend
+       */
+      enabled?: boolean;
+    };
+  };
+}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -85,6 +85,8 @@
     ]
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -151,6 +151,18 @@ const routes = (
             subtitle:
               'Create or modify bcgov GitHub repositories with easy and fast templates for common tools and technologies',
           }}
+          groups={[
+            {
+              title: 'Quickstarts',
+              filter: entity =>
+                entity?.metadata?.tags?.includes('quickstarts') ?? false,
+            },
+            {
+              title: 'TechDocs',
+              filter: entity =>
+                entity?.metadata?.tags?.includes('techdocs') ?? false,
+            },
+          ]}
         />
       }
     />

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -33,6 +33,7 @@ import MenuIcon from '@material-ui/icons/Menu';
 import SearchIcon from '@material-ui/icons/Search';
 import LibraryAddIcon from '@material-ui/icons/LibraryAdd';
 import { CustomSearchModal } from '../search/CustomModal';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 
 const storedTheme = localStorage.getItem('theme');
 
@@ -92,6 +93,10 @@ const SidebarLogo = () => {
 
 export const Root = ({ children }: PropsWithChildren<{}>) => {
   const { state, toggleModal } = useSearchModal();
+  const config = useApi(configApiRef);
+  const wizardsEnabled =
+    config.getOptionalConfig('app.wizards') &&
+    config.getBoolean('app.wizards.enabled');
 
   return (
     <SidebarPage>
@@ -154,7 +159,9 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
         </SidebarItem>
         <SidebarItem icon={ExtensionIcon} to="api-docs" text="APIs" /> */}
           <SidebarItem icon={LibraryBooks} to="docs" text="Docs" />
-          <SidebarItem icon={LibraryAddIcon} to="create" text="Wizards" />
+          {wizardsEnabled ? (
+            <SidebarItem icon={LibraryAddIcon} to="create" text="Wizards" />
+          ) : null}
           {/* <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." /> */}
           {/* End global nav */}
           {/* <SidebarDivider />

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -31,6 +31,7 @@ import {
 // import { useApp } from '@backstage/core-plugin-api';
 import MenuIcon from '@material-ui/icons/Menu';
 import SearchIcon from '@material-ui/icons/Search';
+import LibraryAddIcon from '@material-ui/icons/LibraryAdd';
 import { CustomSearchModal } from '../search/CustomModal';
 
 const storedTheme = localStorage.getItem('theme');
@@ -57,7 +58,7 @@ const useSidebarLogoStyles = makeStyles({
     alignItems: 'center',
     marginBottom: 40,
     paddingTop: 42,
-    marginLeft: -10
+    marginLeft: -10,
   },
   linkOpen: {
     width: sidebarConfig.drawerWidthClosed,
@@ -77,7 +78,12 @@ const SidebarLogo = () => {
 
   return (
     <div className={classes.root}>
-      <Link to="/" underline="none" className={isOpen ? classes.linkOpen : classes.linkClose} aria-label="Home">
+      <Link
+        to="/"
+        underline="none"
+        className={isOpen ? classes.linkOpen : classes.linkClose}
+        aria-label="Home"
+      >
         {isOpen ? <LogoFull /> : <LogoIcon />}
       </Link>
     </div>
@@ -88,28 +94,25 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
   const { state, toggleModal } = useSearchModal();
 
   return (
-  <SidebarPage>
-    <Sidebar>
-      <SidebarLogo />
-      <SidebarGroup label="Search" icon={<SearchIcon />} to="/search">
-      <SearchModalProvider>
-        <SidebarItem
-          className="search-icon"
-          icon={SearchIcon}
-          text="Search"
-          onClick={toggleModal}
-        />
-        <CustomSearchModal
-          {...state}
-          toggleModal={toggleModal}
-        />
-      </SearchModalProvider>
-      </SidebarGroup>
-      <SidebarDivider />
-      <SidebarGroup label="Menu" icon={<MenuIcon />}>
-        <SidebarItem icon={HomeIcon} to="/" text="Home" />
-        {/* Global nav, not org-specific */}
-        {/* <SidebarItem icon={CatalogIcon} to="catalog" text="Catalog">
+    <SidebarPage>
+      <Sidebar>
+        <SidebarLogo />
+        <SidebarGroup label="Search" icon={<SearchIcon />} to="/search">
+          <SearchModalProvider>
+            <SidebarItem
+              className="search-icon"
+              icon={SearchIcon}
+              text="Search"
+              onClick={toggleModal}
+            />
+            <CustomSearchModal {...state} toggleModal={toggleModal} />
+          </SearchModalProvider>
+        </SidebarGroup>
+        <SidebarDivider />
+        <SidebarGroup label="Menu" icon={<MenuIcon />}>
+          <SidebarItem icon={HomeIcon} to="/" text="Home" />
+          {/* Global nav, not org-specific */}
+          {/* <SidebarItem icon={CatalogIcon} to="catalog" text="Catalog">
           <SidebarSubmenu title="Catalog">
           <SidebarSubmenuItem
               title="APIs"
@@ -150,28 +153,32 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
           </SidebarSubmenu>
         </SidebarItem>
         <SidebarItem icon={ExtensionIcon} to="api-docs" text="APIs" /> */}
-        <SidebarItem icon={LibraryBooks} to="docs" text="Docs" />
-        {/* <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." /> */}
-        {/* End global nav */}
-        {/* <SidebarDivider />
+          <SidebarItem icon={LibraryBooks} to="docs" text="Docs" />
+          <SidebarItem icon={LibraryAddIcon} to="create" text="Wizards" />
+          {/* <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." /> */}
+          {/* End global nav */}
+          {/* <SidebarDivider />
         <SidebarScrollWrapper>
           <SidebarItem icon={MapIcon} to="tech-radar" text="Tech Radar" />
         </SidebarScrollWrapper> */}
-      </SidebarGroup>
-      <SidebarSpace />
-      <SidebarGroup
-        label="Offsite Links"
-      >
-        <SidebarItem icon={LaunchIcon} to="https://classic.developer.gov.bc.ca" text="Classic DevHub" />
-      </SidebarGroup>
-      <SidebarGroup
-        label="Settings"
-        icon={<UserSettingsSignInAvatar />}
-        to="/settings"
-      >
-        <SidebarSettings />
-      </SidebarGroup>
-    </Sidebar>
-    {children}
-  </SidebarPage>
-)};
+        </SidebarGroup>
+        <SidebarSpace />
+        <SidebarGroup label="Offsite Links">
+          <SidebarItem
+            icon={LaunchIcon}
+            to="https://classic.developer.gov.bc.ca"
+            text="Classic DevHub"
+          />
+        </SidebarGroup>
+        <SidebarGroup
+          label="Settings"
+          icon={<UserSettingsSignInAvatar />}
+          to="/settings"
+        >
+          <SidebarSettings />
+        </SidebarGroup>
+      </Sidebar>
+      {children}
+    </SidebarPage>
+  );
+};

--- a/packages/app/src/components/home/AnnounceBanner.tsx
+++ b/packages/app/src/components/home/AnnounceBanner.tsx
@@ -1,0 +1,65 @@
+import React, { PropsWithChildren, useState } from 'react';
+import { IconButton, makeStyles, Typography } from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
+import * as tokens from '@bcgov/design-tokens/js';
+
+const useStyles = makeStyles(theme => ({
+  background: {
+    display: 'flex',
+    justifyContent: 'center',
+    margin: `-${tokens.layoutMarginLarge} -${tokens.layoutMarginLarge} ${tokens.layoutMarginLarge}`,
+    background:
+      theme.palette.type === 'dark'
+        ? tokens.themeGray90
+        : tokens.surfaceColorBackgroundLightGray,
+    boxShadow: tokens.surfaceShadowSmall,
+  },
+  content: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.layoutMarginSmall,
+  },
+  closeBtn: {
+    marginLeft: tokens.layoutMarginXxlarge,
+  },
+}));
+
+interface AnnounceBannerProps {
+  id: number; // increment the element's id for new announcements
+  title: string;
+}
+
+export const AnnounceBanner = ({
+  children,
+  ...props
+}: PropsWithChildren<AnnounceBannerProps>) => {
+  const classes = useStyles();
+  const bannerStateId = localStorage.getItem('announceBannerStateId');
+  // show the banner if announceBannerStateId is unset, or for a previous announcement
+  const [isOpen, setIsOpen] = useState(
+    !bannerStateId || +bannerStateId < props.id,
+  );
+
+  if (!isOpen) return null;
+
+  const closeBanner = () => {
+    localStorage.setItem('announceBannerStateId', `${props.id}`);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className={classes.background}>
+      <div className={classes.content}>
+        <Typography variant="h6">{props.title}</Typography>
+        {children}
+        <IconButton
+          className={classes.closeBtn}
+          onClick={closeBanner}
+          aria-label="close"
+        >
+          <CloseIcon />
+        </IconButton>
+      </div>
+    </div>
+  );
+};

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import { BCGovBannerText, BCGovHeaderText } from './HomeHeaderText';
 import { HomePageCards } from './HomePageCards';
 import { AnnounceBanner } from './AnnounceBanner';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import * as tokens from '@bcgov/design-tokens/js';
 
 const useStyles = makeStyles({
@@ -67,17 +68,23 @@ const GlobalStyle = createGlobalStyle`
 
 const HomePage = () => {
   const classes = useStyles();
+  const config = useApi(configApiRef);
+  const wizardsEnabled =
+    config.getOptionalConfig('app.wizards') &&
+    config.getBoolean('app.wizards.enabled');
 
   return (
     <Page themeId="home">
       <GlobalStyle />
       <Content>
-        <AnnounceBanner id={0} title="Quickstart wizards launch">
-          <Typography>
-            reduce startup times for new apps with the{' '}
-            <Link to="/create">OpenShift quickstart wizard</Link>
-          </Typography>
-        </AnnounceBanner>
+        {wizardsEnabled ? (
+          <AnnounceBanner id={0} title="Quickstart wizards launch">
+            <Typography>
+              reduce startup times for new apps with the{' '}
+              <Link to="/create">OpenShift quickstart wizard</Link>
+            </Typography>
+          </AnnounceBanner>
+        ) : null}
 
         <div className={classes.root}>
           <BCGovBannerText variant="h2" gutterBottom>

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -1,57 +1,58 @@
 import React from 'react';
-import {createGlobalStyle} from 'styled-components';
-import {Content, Page} from '@backstage/core-components';
-import {HomePageSearchBar} from "@backstage/plugin-search";
-import {makeStyles, Typography} from "@material-ui/core";
+import { createGlobalStyle } from 'styled-components';
+import { Content, Page } from '@backstage/core-components';
+import { HomePageSearchBar } from '@backstage/plugin-search';
+import { makeStyles, Typography } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 import { BCGovBannerText, BCGovHeaderText } from './HomeHeaderText';
 import { HomePageCards } from './HomePageCards';
-import * as tokens from "@bcgov/design-tokens/js";
+import { AnnounceBanner } from './AnnounceBanner';
+import * as tokens from '@bcgov/design-tokens/js';
 
 const useStyles = makeStyles({
-	searchBar: {
-		display: 'flex',
-		width: '65%',
-		boxShadow: tokens.surfaceShadowSmall,
-		padding: `${tokens.layoutPaddingSmall} 0`,
-		borderRadius: '50px',
-		margin: `${tokens.layoutMarginXlarge} auto`,
-		border: `${tokens.layoutBorderWidthSmall} solid ${tokens.themeGray80}`,
-		'@media (max-width: 700px)': {
-			width: '90%',
-		}
-	},
-	searchBarOutline: {
-		borderStyle: 'none',
-	},
-	root: {
-		padding: `calc(2.1rem - ${tokens.layoutPaddingLarge}) 9% ${tokens.layoutPaddingNone}`,
-	},
-	feedback: {
-		padding: `${tokens.layoutMarginXxxlarge} 9%`,
-	},
-	cardRecon: {
-		color: tokens.typographyColorPrimaryInvert,
-		backgroundColor: tokens.themeGray100,
-		padding: `${tokens.layoutPaddingXlarge} 9%`,
-	},
-	footer: {
-		width: 'auto',
-		marginLeft: `-${tokens.layoutMarginLarge}`,
-		marginRight: `-${tokens.layoutMarginLarge}`,
-		marginBottom: tokens.layoutMarginXxxlarge,
-		borderTop: `${tokens.layoutBorderWidthLarge} solid ${tokens.themePrimaryGold}`,
-		borderBottom: `${tokens.layoutBorderWidthLarge} solid ${tokens.themePrimaryGold}`,
-	}
+  searchBar: {
+    display: 'flex',
+    width: '65%',
+    boxShadow: tokens.surfaceShadowSmall,
+    padding: `${tokens.layoutPaddingSmall} 0`,
+    borderRadius: '50px',
+    margin: `${tokens.layoutMarginXlarge} auto`,
+    border: `${tokens.layoutBorderWidthSmall} solid ${tokens.themeGray80}`,
+    '@media (max-width: 700px)': {
+      width: '90%',
+    },
+  },
+  searchBarOutline: {
+    borderStyle: 'none',
+  },
+  root: {
+    padding: `calc(2.1rem - ${tokens.layoutPaddingLarge}) 9% ${tokens.layoutPaddingNone}`,
+  },
+  feedback: {
+    padding: `${tokens.layoutMarginXxxlarge} 9%`,
+  },
+  cardRecon: {
+    color: tokens.typographyColorPrimaryInvert,
+    backgroundColor: tokens.themeGray100,
+    padding: `${tokens.layoutPaddingXlarge} 9%`,
+  },
+  footer: {
+    width: 'auto',
+    marginLeft: `-${tokens.layoutMarginLarge}`,
+    marginRight: `-${tokens.layoutMarginLarge}`,
+    marginBottom: tokens.layoutMarginXxxlarge,
+    borderTop: `${tokens.layoutBorderWidthLarge} solid ${tokens.themePrimaryGold}`,
+    borderBottom: `${tokens.layoutBorderWidthLarge} solid ${tokens.themePrimaryGold}`,
+  },
 });
 makeStyles({
-	svg: {
-		width: 'auto',
-		height: 100,
-	},
-	path: {
-		fill: '#7df3e1',
-	},
+  svg: {
+    width: 'auto',
+    height: 100,
+  },
+  path: {
+    fill: '#7df3e1',
+  },
 });
 
 const GlobalStyle = createGlobalStyle`
@@ -65,48 +66,71 @@ const GlobalStyle = createGlobalStyle`
 	}`;
 
 const HomePage = () => {
-	const classes = useStyles();
+  const classes = useStyles();
 
-	return (
-		<Page themeId="home">
-			<GlobalStyle />
-			<Content>
-				<div className={classes.root}>
-					<BCGovBannerText variant="h2" gutterBottom>B.C. government DevHub</BCGovBannerText>
-					<Typography>
-						The B.C. government DevHub is a place to access common technical documentation, community knowledge bases, code samples and APIs.
-					</Typography>
+  return (
+    <Page themeId="home">
+      <GlobalStyle />
+      <Content>
+        <AnnounceBanner id={0} title="Quickstart wizards launch">
+          <Typography>
+            reduce startup times for new apps with the{' '}
+            <Link to="/create">OpenShift quickstart wizard</Link>
+          </Typography>
+        </AnnounceBanner>
 
-					<HomePageSearchBar
-						classes={{ root: classes.searchBar }}
-						InputProps={{classes: {notchedOutline: classes.searchBarOutline}}}
-						placeholder="Search all DevHub resources"
-					/>
-				</div>
+        <div className={classes.root}>
+          <BCGovBannerText variant="h2" gutterBottom>
+            B.C. government DevHub
+          </BCGovBannerText>
+          <Typography>
+            The B.C. government DevHub is a place to access common technical
+            documentation, community knowledge bases, code samples and APIs.
+          </Typography>
 
-				<HomePageCards />
+          <HomePageSearchBar
+            classes={{ root: classes.searchBar }}
+            InputProps={{
+              classes: { notchedOutline: classes.searchBarOutline },
+            }}
+            placeholder="Search all DevHub resources"
+          />
+        </div>
 
-				<div className={classes.feedback}>
-					<BCGovHeaderText variant="h3" paragraph>
-						Provide feedback
-					</BCGovHeaderText>
-					<Typography>
-						The B.C. government DevHub is managed by the Developer Experience team. Join us as we work together to create impactful solutions by <Link style={{ textDecoration: 'underline' }} to='mailto:developer.experience@gov.bc.ca'>providing feedback</Link> or participating in user research.
-					</Typography>
-				</div>
+        <HomePageCards />
 
-				<div className={classes.footer}>
-					<div className={classes.cardRecon}>
-						<Typography variant='body2'>
-							The B.C. Public Service acknowledges the territories of First Nations around B.C. and is grateful to carry out our work on these lands.
-							We acknowledge the rights, interests, priorities and concerns of all Indigenous Peoples - First Nations, Métis and Inuit - respecting and acknowledging their distinct cultures, histories, rights, laws and governments.
-						</Typography>
-					</div>
-				</div>
+        <div className={classes.feedback}>
+          <BCGovHeaderText variant="h3" paragraph>
+            Provide feedback
+          </BCGovHeaderText>
+          <Typography>
+            The B.C. government DevHub is managed by the Developer Experience
+            team. Join us as we work together to create impactful solutions by{' '}
+            <Link
+              style={{ textDecoration: 'underline' }}
+              to="mailto:developer.experience@gov.bc.ca"
+            >
+              providing feedback
+            </Link>{' '}
+            or participating in user research.
+          </Typography>
+        </div>
 
-			</Content>
-		</Page>
-	);
+        <div className={classes.footer}>
+          <div className={classes.cardRecon}>
+            <Typography variant="body2">
+              The B.C. Public Service acknowledges the territories of First
+              Nations around B.C. and is grateful to carry out our work on these
+              lands. We acknowledge the rights, interests, priorities and
+              concerns of all Indigenous Peoples - First Nations, Métis and
+              Inuit - respecting and acknowledging their distinct cultures,
+              histories, rights, laws and governments.
+            </Typography>
+          </div>
+        </div>
+      </Content>
+    </Page>
+  );
 };
 
 export default HomePage;

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -50,6 +50,7 @@
     "@backstage/plugin-search-backend-node": "^1.3.4",
     "@backstage/plugin-techdocs-backend": "^1.11.1",
     "@roadiehq/scaffolder-backend-module-http-request": "^4.3.5",
+    "@roadiehq/scaffolder-backend-module-utils": "^3.3.0",
     "app": "link:../app",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -14,6 +14,7 @@ backend.add(import('@backstage/plugin-scaffolder-backend-module-github'));
 backend.add(
   import('@roadiehq/scaffolder-backend-module-http-request/new-backend'),
 );
+backend.add(import('@roadiehq/scaffolder-backend-module-utils'));
 backend.add(import('@backstage/plugin-auth-backend'));
 backend.add(import('@backstage/plugin-auth-backend-module-github-provider'));
 backend.add(import('@backstage/plugin-search-backend'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2450,6 +2450,22 @@
     knex "^3.0.0"
     luxon "^3.0.0"
 
+"@backstage/backend-plugin-api@^1.0.2", "@backstage/backend-plugin-api@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@backstage/backend-plugin-api/-/backend-plugin-api-1.1.1.tgz#8ec828a3ec4c7a1c6a08edce26f2fb0e971e56d8"
+  integrity sha512-25+CpNPM4N9rfEO9rKcy0632Ph8UblTfxCltHoG/q4EPejMh3vixB6bzkLG8nDioQnswH13k4nmiRxQr4w4gBg==
+  dependencies:
+    "@backstage/cli-common" "^0.1.15"
+    "@backstage/config" "^1.3.2"
+    "@backstage/errors" "^1.2.7"
+    "@backstage/plugin-auth-node" "^0.5.6"
+    "@backstage/plugin-permission-common" "^0.8.4"
+    "@backstage/types" "^1.2.1"
+    "@types/express" "^4.17.6"
+    "@types/luxon" "^3.0.0"
+    knex "^3.0.0"
+    luxon "^3.0.0"
+
 "@backstage/catalog-client@^1.7.1":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@backstage/catalog-client/-/catalog-client-1.7.1.tgz#f85f4cfee20a25be556cc572e12f58e4b8cb1309"
@@ -2457,6 +2473,16 @@
   dependencies:
     "@backstage/catalog-model" "^1.7.0"
     "@backstage/errors" "^1.2.4"
+    cross-fetch "^4.0.0"
+    uri-template "^2.0.0"
+
+"@backstage/catalog-client@^1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@backstage/catalog-client/-/catalog-client-1.9.1.tgz#f625895a019778111b4ece0373a5ac2adabf08a4"
+  integrity sha512-8LpTbW3QQoNDNvPtHAlr1BUEbOZsbj2iGHbaZWBM6Hc+jHfl+VQC6pkHnG3XoeU6prXY/j6o4p/fDuxYEX22sQ==
+  dependencies:
+    "@backstage/catalog-model" "^1.7.3"
+    "@backstage/errors" "^1.2.7"
     cross-fetch "^4.0.0"
     uri-template "^2.0.0"
 
@@ -2470,10 +2496,25 @@
     ajv "^8.10.0"
     lodash "^4.17.21"
 
+"@backstage/catalog-model@^1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@backstage/catalog-model/-/catalog-model-1.7.3.tgz#c74f680cbdbe4209a4a9c17de34b1949f1d19a2d"
+  integrity sha512-eqSRo7briHyVXMBkNdgQ8rdrw5W2LZifqrIabGwjcvoV8YDG2hFBuCPfqpdpfsgeCIk45iyXilTi9rg1Nt1fgw==
+  dependencies:
+    "@backstage/errors" "^1.2.7"
+    "@backstage/types" "^1.2.1"
+    ajv "^8.10.0"
+    lodash "^4.17.21"
+
 "@backstage/cli-common@^0.1.14":
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/@backstage/cli-common/-/cli-common-0.1.14.tgz#2291520acfbac860a05dd48fc3b876d5cd789b76"
   integrity sha512-4kGWGrFuxoaCne2aHCOVW+vi8y2MLEMEj785SEApMG2J8jXJXUuIOzWw0MrN0pM1FqBXDb6aeQd+bmQMK/Ci+w==
+
+"@backstage/cli-common@^0.1.15":
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/@backstage/cli-common/-/cli-common-0.1.15.tgz#20ea69cdee5025bdbdba38492ec174b1d8d470e3"
+  integrity sha512-z+jMq5h+J1ruZ0IC610QFfSQxLk3IGSL1pZ/xnEIbyohaak+eeOZCyNzKBLwQrBDnIFCdmMoq69/Vrejo2hPeA==
 
 "@backstage/cli-node@^0.2.9":
   version "0.2.9"
@@ -2640,6 +2681,15 @@
   dependencies:
     "@backstage/errors" "^1.2.4"
     "@backstage/types" "^1.1.1"
+
+"@backstage/config@^1.3.0", "@backstage/config@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@backstage/config/-/config-1.3.2.tgz#ddea2f7646fba459316566dad770af9265dd1241"
+  integrity sha512-9na5EAf5AJzrwAysnIbNqFmPN1ES9IiUwy9uGMhwFzxXeHjDz+RAmiqFYFL6tNMwuFwrW1zxpvzKAUXvvYDe6Q==
+  dependencies:
+    "@backstage/errors" "^1.2.7"
+    "@backstage/types" "^1.2.1"
+    ms "^2.1.3"
 
 "@backstage/core-app-api@^1.14.2", "@backstage/core-app-api@^1.15.1":
   version "1.15.1"
@@ -2843,6 +2893,14 @@
     "@backstage/types" "^1.1.1"
     serialize-error "^8.0.1"
 
+"@backstage/errors@^1.2.5", "@backstage/errors@^1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@backstage/errors/-/errors-1.2.7.tgz#6da0251d78192328e1b7893420b92aec90df5aad"
+  integrity sha512-XsH0w4hW0aJs3NuANbvgpQoKrQGYIMUaVKeDoGO/99uDgBbJ2QyDb/m9onbKV7tG9HkEe/NKixKqRhxRLx4wzA==
+  dependencies:
+    "@backstage/types" "^1.2.1"
+    serialize-error "^8.0.1"
+
 "@backstage/eslint-plugin@^0.1.10":
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/@backstage/eslint-plugin/-/eslint-plugin-0.1.10.tgz#8f786ccc3c315dfe9b1cd3aa6d8435fd266a0574"
@@ -2939,6 +2997,22 @@
     "@azure/identity" "^4.0.0"
     "@backstage/config" "^1.2.0"
     "@backstage/errors" "^1.2.4"
+    "@octokit/auth-app" "^4.0.0"
+    "@octokit/rest" "^19.0.3"
+    cross-fetch "^4.0.0"
+    git-url-parse "^15.0.0"
+    lodash "^4.17.21"
+    luxon "^3.0.0"
+
+"@backstage/integration@^1.16.1":
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/@backstage/integration/-/integration-1.16.1.tgz#0282c7f4d5ef63479a838a39401750adde43032a"
+  integrity sha512-HDJo+TTiup/vj308plzQSo12kFk3BIY6fSPm9V1FgijDRq5145+iMcJAhQf/dGMIykXTQ+Dsc+FMJfCPO5VRMA==
+  dependencies:
+    "@azure/identity" "^4.0.0"
+    "@azure/storage-blob" "^12.5.0"
+    "@backstage/config" "^1.3.2"
+    "@backstage/errors" "^1.2.7"
     "@octokit/auth-app" "^4.0.0"
     "@octokit/rest" "^19.0.3"
     cross-fetch "^4.0.0"
@@ -3310,6 +3384,29 @@
     jose "^5.0.0"
     lodash "^4.17.21"
     node-fetch "^2.7.0"
+    passport "^0.7.0"
+    winston "^3.2.1"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.21.4"
+    zod-validation-error "^3.4.0"
+
+"@backstage/plugin-auth-node@^0.5.6":
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-auth-node/-/plugin-auth-node-0.5.6.tgz#1e2a55e95f5cd548e5f522682cd616383fa176cb"
+  integrity sha512-C3hI7gB0hQwc/NORjZYDB368UTbZe1g2md8LHfTLeIeuyoZyFGAODKZa0XCwLFAX99awttkVeuOjffNLR295Sw==
+  dependencies:
+    "@backstage/backend-common" "^0.25.0"
+    "@backstage/backend-plugin-api" "^1.1.1"
+    "@backstage/catalog-client" "^1.9.1"
+    "@backstage/catalog-model" "^1.7.3"
+    "@backstage/config" "^1.3.2"
+    "@backstage/errors" "^1.2.7"
+    "@backstage/types" "^1.2.1"
+    "@types/express" "^4.17.6"
+    "@types/passport" "^1.0.3"
+    express "^4.17.1"
+    jose "^5.0.0"
+    lodash "^4.17.21"
     passport "^0.7.0"
     winston "^3.2.1"
     zod "^3.22.4"
@@ -3701,6 +3798,19 @@
     zod "^3.22.4"
     zod-to-json-schema "^3.20.4"
 
+"@backstage/plugin-permission-common@^0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-common/-/plugin-permission-common-0.8.4.tgz#9f9a166041853833b50e844bbe35a2d9b9aca37f"
+  integrity sha512-zZSfXadycRCP/YG2Cf4p/hxDU4fhrYDAVneo9PKZMfy3O4ERdtrYehGuOspcak2NkeMmaj2KfsFuWFuWK2xBTQ==
+  dependencies:
+    "@backstage/config" "^1.3.2"
+    "@backstage/errors" "^1.2.7"
+    "@backstage/types" "^1.2.1"
+    cross-fetch "^4.0.0"
+    uuid "^11.0.0"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.20.4"
+
 "@backstage/plugin-permission-node@^0.8.4":
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-permission-node/-/plugin-permission-node-0.8.4.tgz#8e1f43d4e3c9ea13b53c3704bff4a463e3d10463"
@@ -3937,6 +4047,15 @@
     "@backstage/plugin-permission-common" "^0.8.1"
     "@backstage/types" "^1.1.1"
 
+"@backstage/plugin-scaffolder-common@^1.5.9":
+  version "1.5.9"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-scaffolder-common/-/plugin-scaffolder-common-1.5.9.tgz#20525c1f9a4c5edde689a6e186cfa7642bf37d4c"
+  integrity sha512-lcUQDzn/YjnsBnMGVA+Z7XbDS7T4nc8wdMO+D15WDfkC/WVVmWdRnlkfM0UTuWPg7QMIkUtqpFplidkNNwWf5w==
+  dependencies:
+    "@backstage/catalog-model" "^1.7.3"
+    "@backstage/plugin-permission-common" "^0.8.4"
+    "@backstage/types" "^1.2.1"
+
 "@backstage/plugin-scaffolder-node@^0.4.9":
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/@backstage/plugin-scaffolder-node/-/plugin-scaffolder-node-0.4.11.tgz#22d8e6faf42af551963ea91b364969e6163acd47"
@@ -3972,6 +4091,29 @@
     "@backstage/integration" "^1.15.1"
     "@backstage/plugin-scaffolder-common" "^1.5.6"
     "@backstage/types" "^1.1.1"
+    concat-stream "^2.0.0"
+    fs-extra "^11.2.0"
+    globby "^11.0.0"
+    isomorphic-git "^1.23.0"
+    jsonschema "^1.2.6"
+    p-limit "^3.1.0"
+    tar "^6.1.12"
+    winston "^3.2.1"
+    zod "^3.22.4"
+    zod-to-json-schema "^3.20.4"
+
+"@backstage/plugin-scaffolder-node@^0.6.2":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@backstage/plugin-scaffolder-node/-/plugin-scaffolder-node-0.6.3.tgz#2914f776dc42e0844aaedf856f644fd4c56cfc59"
+  integrity sha512-CuX9V3k6iI+SWFcW5O0qLQ6a2ERkDCxjMhLCTDna71r0j0s+FIuIJdqsAh/tIX0mbypHNtIPXO0ruNA5Z8/UxA==
+  dependencies:
+    "@backstage/backend-common" "^0.25.0"
+    "@backstage/backend-plugin-api" "^1.1.1"
+    "@backstage/catalog-model" "^1.7.3"
+    "@backstage/errors" "^1.2.7"
+    "@backstage/integration" "^1.16.1"
+    "@backstage/plugin-scaffolder-common" "^1.5.9"
+    "@backstage/types" "^1.2.1"
     concat-stream "^2.0.0"
     fs-extra "^11.2.0"
     globby "^11.0.0"
@@ -4444,6 +4586,11 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@backstage/types/-/types-1.1.1.tgz#c9ccb30357005e7fb5fa2ac140198059976eb076"
   integrity sha512-1cUGu+FwiJZCBOuecd0BOhIRkQYllb+7no9hHhxpAsx/DvsPGMVQMGOMvtdTycdT9SQ5MuSyFwI9wpXp2DwVvQ==
+
+"@backstage/types@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@backstage/types/-/types-1.2.1.tgz#8c15c71e6b629806d3dc00227aaa4fd1c19cef16"
+  integrity sha512-0GkrZthoIkUzoeop+8fZZk2MWlLd1q0LB59tMarsjw7ccMtFYR96jhlf1qGvcbw7Gn5ETtJfTC2C1aUzvgvF+w==
 
 "@backstage/version-bridge@^1.0.10", "@backstage/version-bridge@^1.0.7", "@backstage/version-bridge@^1.0.8":
   version "1.0.10"
@@ -7567,6 +7714,25 @@
     cross-fetch "^4.0.0"
     winston "^3.2.1"
 
+"@roadiehq/scaffolder-backend-module-utils@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@roadiehq/scaffolder-backend-module-utils/-/scaffolder-backend-module-utils-3.3.0.tgz#d546fd13ce82727af753c96c7ebaeeaec84ed062"
+  integrity sha512-XqQNafbQ5paaose2vLaAeXFxKGDf7gsXhWeqOJcLjjsNHRVWiv0W1r6zaSvMLTao5JPkYuwnDX6g0stMmKnJ4g==
+  dependencies:
+    "@backstage/backend-plugin-api" "^1.0.2"
+    "@backstage/config" "^1.3.0"
+    "@backstage/errors" "^1.2.5"
+    "@backstage/plugin-scaffolder-node" "^0.6.2"
+    adm-zip "^0.5.9"
+    cross-fetch "^3.1.4"
+    detect-indent "^6.1.0"
+    fs-extra "^10.0.0"
+    jsonata "^2.0.4"
+    lodash "^4.17.21"
+    winston "^3.2.1"
+    yaml "^2.6.1"
+    yawn-yaml "^2.3.0"
+
 "@rollup/plugin-commonjs@^26.0.0":
   version "26.0.3"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-26.0.3.tgz#085ffb49818e43e4a2a96816a37affcc8a8cbaca"
@@ -9864,12 +10030,17 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
-"@types/react-dom@*", "@types/react-dom@<18.0.0", "@types/react-dom@^18", "@types/react-dom@^18.0.0":
+"@types/react-dom@*", "@types/react-dom@^18.0.0":
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.1.tgz#1e4654c08a9cdcfb6594c780ac59b55aad42fe07"
   integrity sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==
   dependencies:
     "@types/react" "*"
+
+"@types/react-dom@<18.0.0":
+  version "17.0.26"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.26.tgz#fa7891ba70fd39ddbaa7e85b6ff9175bb546bc1b"
+  integrity sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==
 
 "@types/react-redux@^7.1.20":
   version "7.1.34"
@@ -9902,12 +10073,21 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.13.1 || ^17.0.0", "@types/react@^16.13.1 || ^17.0.0 || ^18.0.0", "@types/react@^18":
+"@types/react@*", "@types/react@^16.13.1 || ^17.0.0 || ^18.0.0":
   version "18.3.12"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.12.tgz#99419f182ccd69151813b7ee24b792fe08774f60"
   integrity sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==
   dependencies:
     "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@^16.13.1 || ^17.0.0":
+  version "17.0.83"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.83.tgz#b477c56387b74279281149dcf5ba2a1e2216d131"
+  integrity sha512-l0m4ArKJvmFtR4e8UmKrj1pB4tUgOhJITf+mADyF/p69Ts1YAR/E+G9XEM0mHXKVRa1dQNHseyyDNzeuAXfXQw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "^0.16"
     csstype "^3.0.2"
 
 "@types/request@^2.47.1", "@types/request@^2.48.8":
@@ -9936,6 +10116,11 @@
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.2.tgz#ed279a64fa438bb69f2480eda44937912bb7480a"
   integrity sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==
+
+"@types/scheduler@^0.16":
+  version "0.16.8"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.8.tgz#ce5ace04cfeabe7ef87c0091e50752e36707deff"
+  integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
 "@types/semver@7.5.8", "@types/semver@^7.5.0":
   version "7.5.8"
@@ -10555,7 +10740,7 @@ address@^1.0.1, address@^1.1.2:
   resolved "https://registry.yarnpkg.com/address/-/address-1.2.2.tgz#2b5248dac5485a6390532c6a517fda2e3faac89e"
   integrity sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==
 
-adm-zip@^0.5.10:
+adm-zip@^0.5.10, adm-zip@^0.5.9:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.16.tgz#0b5e4c779f07dedea5805cdccb1147071d94a909"
   integrity sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==
@@ -13760,6 +13945,11 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==
+
+detect-indent@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
+  integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
 
 detect-libc@^2.0.0:
   version "2.0.3"
@@ -18065,6 +18255,11 @@ json5@^2.1.2, json5@^2.1.3, json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+jsonata@^2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/jsonata/-/jsonata-2.0.6.tgz#1187ec97f4662d6857b1cc40770f3ea61345d04c"
+  integrity sha512-WhQB5tXQ32qjkx2GYHFw2XbL90u+LLzjofAYwi+86g6SyZeXHz9F1Q0amy3dWRYczshOC3Haok9J4pOCgHtwyQ==
 
 jsonc-parser@3.2.0:
   version "3.2.0"
@@ -25843,6 +26038,11 @@ utils-merge@1.0.1, utils-merge@1.x.x, utils-merge@^1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@^11.0.0:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.5.tgz#07b46bdfa6310c92c3fb3953a8720f170427fc62"
+  integrity sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==
+
 uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
@@ -26577,6 +26777,11 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml-js@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/yaml-js/-/yaml-js-0.3.1.tgz#8f6f4300063364c2778be30f220736ae5e92c23c"
+  integrity sha512-LjoIFHCtSfkGzPsmYmfDsW+TShtQBcY7lwH1yLQ5brJHXRhjteUnVE2ThCbz1madq8JUZIAjFiavfnIFeTO8CQ==
+
 yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
@@ -26586,6 +26791,11 @@ yaml@^2.0.0, yaml@^2.2.1:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.6.0.tgz#14059ad9d0b1680d0f04d3a60fe00f3a857303c3"
   integrity sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==
+
+yaml@^2.6.1:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.7.0.tgz#aef9bb617a64c937a9a748803786ad8d3ffe1e98"
+  integrity sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==
 
 yaml@~2.5.0:
   version "2.5.1"
@@ -26640,6 +26850,15 @@ yauzl@^3.0.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     pend "~1.2.0"
+
+yawn-yaml@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/yawn-yaml/-/yawn-yaml-2.3.0.tgz#79b2cdd58b7abe243c9b0418997795e5754b7135"
+  integrity sha512-hYS8kT4I2ftJyLw6LE/JG8rg+0NKdDmI+c2ncnJ9ZmUTsU0ggo3Zf8yjmhXxKlWINS/ZYkh3MvMIsQlIDtRL4A==
+  dependencies:
+    js-yaml "^4.1.0"
+    lodash "^4.17.21"
+    yaml-js "^0.3.1"
 
 ylru@^1.2.0:
   version "1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10030,17 +10030,10 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
-"@types/react-dom@*", "@types/react-dom@^18.0.0":
-  version "18.3.1"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.1.tgz#1e4654c08a9cdcfb6594c780ac59b55aad42fe07"
-  integrity sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-dom@<18.0.0":
-  version "17.0.26"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.26.tgz#fa7891ba70fd39ddbaa7e85b6ff9175bb546bc1b"
-  integrity sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==
+"@types/react-dom@*", "@types/react-dom@<18.0.0", "@types/react-dom@^18", "@types/react-dom@^18.0.0":
+  version "18.3.5"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.5.tgz#45f9f87398c5dcea085b715c58ddcf1faf65f716"
+  integrity sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==
 
 "@types/react-redux@^7.1.20":
   version "7.1.34"
@@ -10073,21 +10066,12 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.13.1 || ^17.0.0 || ^18.0.0":
-  version "18.3.12"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.12.tgz#99419f182ccd69151813b7ee24b792fe08774f60"
-  integrity sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==
+"@types/react@*", "@types/react@^16.13.1 || ^17.0.0", "@types/react@^16.13.1 || ^17.0.0 || ^18.0.0", "@types/react@^18":
+  version "18.3.18"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.18.tgz#9b382c4cd32e13e463f97df07c2ee3bbcd26904b"
+  integrity sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==
   dependencies:
     "@types/prop-types" "*"
-    csstype "^3.0.2"
-
-"@types/react@^16.13.1 || ^17.0.0":
-  version "17.0.83"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.83.tgz#b477c56387b74279281149dcf5ba2a1e2216d131"
-  integrity sha512-l0m4ArKJvmFtR4e8UmKrj1pB4tUgOhJITf+mADyF/p69Ts1YAR/E+G9XEM0mHXKVRa1dQNHseyyDNzeuAXfXQw==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "^0.16"
     csstype "^3.0.2"
 
 "@types/request@^2.47.1", "@types/request@^2.48.8":
@@ -10116,11 +10100,6 @@
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.2.tgz#ed279a64fa438bb69f2480eda44937912bb7480a"
   integrity sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==
-
-"@types/scheduler@^0.16":
-  version "0.16.8"
-  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.8.tgz#ce5ace04cfeabe7ef87c0091e50752e36707deff"
-  integrity sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==
 
 "@types/semver@7.5.8", "@types/semver@^7.5.0":
   version "7.5.8"


### PR DESCRIPTION
There are several new additions here:

* The `app.wizards.enabled` config option. Toggled off currently.

* /create page groupings. Wizards/templates with "quickstarts" or "techdocs" tags will group together.
![image](https://github.com/user-attachments/assets/2dc3d8c4-5fed-4a98-b3f4-4bd94776f6c1)

* Added "Wizards" sidebar item. Currently toggled off via new config option.
![image](https://github.com/user-attachments/assets/1fa08b4f-ca1b-40be-9015-2a2ed6ee7d9c)

* Created the `AnnounceBanner` component. Currently toggled off via new config option. This displays the wizards announcement and links off to /create. 
![image](https://github.com/user-attachments/assets/9c1ebb2c-ca30-4c7e-a838-15a54414c89b)
I just realized Backstage does have a `DismissableBanner` component, but it looks like a pop-up with info/warn/error styling, so I think this is better.

* I also added the `@roadiehq/scaffolder-backend-module-utils` package, this includes a bunch of useful scaffolder actions. I'm using the `roadiehq:utils:fs:replace` action in the openshift quickstart wizard.
