### PR TITLE
Update node version for version-bump workflow

### DIFF
--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: cache all node_modules


### PR DESCRIPTION
Update node version from 18 to 20 for the [version-bump.yaml](https://github.com/bcgov/developer-portal/blob/645896fb26f0455d77d491c1ffebc6a131ee8b33/.github/workflows/version-bump.yaml) workflow. 

The workflow was [failing](https://github.com/bcgov/developer-portal/actions/runs/13620757694) with version 18.
