### PR TITLE
remove bcgov-public org

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -110,7 +110,7 @@ catalog:
     githubOrg:
       - id: production
         githubUrl: 'https://github.com'
-        orgs: ['bcgov', 'bcgov-public']
+        orgs: ['bcgov']
         schedule:
           frequency: { minutes: 60 }
           timeout: { minutes: 15 }

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,5 +9,5 @@ metadata:
   #   backstage.io/techdocs-ref: dir:.
 spec:
   type: website
-  owner: group:bcgov/exchange-lab-developer-portal-team
+  owner: group:exchange-lab-developer-portal-team
   lifecycle: experimental


### PR DESCRIPTION
The `bcgov-public` org was a trial Enterprise org setup in the summer of 2024 to test GitHub cloud Enterprise.

It is no longer used and is set to be deleted by GitHub on April 21st.

This PR is to remove `bcgov-public` from DevHub integration.
 
