### PR TITLE
Remove classic links from home and 404

### DIFF
--- a/packages/app/src/components/404/Custom404Page.tsx
+++ b/packages/app/src/components/404/Custom404Page.tsx
@@ -114,13 +114,7 @@ export function Custom404Page() {
             </Grid>
             <Box pt={5}>
               <Typography variant="h6">
-                <Link
-                  className={classes.link}
-                  to={`https://classic.developer.gov.bc.ca/?q=${preFiltered.term}`}
-                >
-                  Search Classic DevHub
-                </Link>
-                &nbsp;- please{' '}
+                Please{' '}
                 <Link
                   className={classes.link}
                   to="https://github.com/bcgov/developer-portal/issues"

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -5,7 +5,6 @@ import HomeIcon from '@material-ui/icons/Home';
 // import ExtensionIcon from '@material-ui/icons/Extension';
 // import MapIcon from '@material-ui/icons/MyLocation';
 import LibraryBooks from '@material-ui/icons/LibraryBooks';
-import LaunchIcon from '@material-ui/icons/Launch';
 // import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
 import LogoFull from './LogoFull';
 import { LogoIcon } from './LogoIcon';
@@ -170,13 +169,6 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
         </SidebarScrollWrapper> */}
         </SidebarGroup>
         <SidebarSpace />
-        <SidebarGroup label="Offsite Links">
-          <SidebarItem
-            icon={LaunchIcon}
-            to="https://classic.developer.gov.bc.ca"
-            text="Classic DevHub"
-          />
-        </SidebarGroup>
         <SidebarGroup
           label="Settings"
           icon={<UserSettingsSignInAvatar />}


### PR DESCRIPTION
I removed the side bar link to classic, as well as the link to "Search Classic DevHub" from the 404 page.