### PR TITLE
DEVXT-2236: Permission updates

### DIFF
--- a/.github/workflows/build-update-gitops-pr-branch.yaml
+++ b/.github/workflows/build-update-gitops-pr-branch.yaml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   get-build-mode:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       SHOULD_BUILD: ${{ steps.build_mode.outputs.SHOULD_BUILD }}
       SHOULD_BUILD_DEPLOY: ${{ steps.build_mode.outputs.SHOULD_BUILD_DEPLOY }}
@@ -58,6 +59,7 @@ jobs:
   update-gitops-pr-file:
     if: needs.get-build-mode.outputs.SHOULD_BUILD_DEPLOY == 'true'
     runs-on: ubuntu-latest
+    permissions: {}
     needs:
       [call-build-workflow, get-short-sha, get-pr-branch-name, get-build-mode]
 

--- a/.github/workflows/build-update-gitops.yaml
+++ b/.github/workflows/build-update-gitops.yaml
@@ -31,6 +31,7 @@ jobs:
 
   update-gitops-file:
     runs-on: ubuntu-latest
+    permissions: {}
     needs: [call-build-workflow, get-short-sha]
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/delete-gitops-branch.yaml
+++ b/.github/workflows/delete-gitops-branch.yaml
@@ -1,5 +1,5 @@
 name: Delete gitops deployment branch
-
+permissions: {}
 on:
   pull_request:
     types: [unlabeled, closed]

--- a/.github/workflows/get-pr-branch-name.yaml
+++ b/.github/workflows/get-pr-branch-name.yaml
@@ -1,19 +1,18 @@
 name: Get PR branch name
-
+permissions: {}
 on:
-    workflow_call:
-      outputs:
-        BRANCH_NAME:
-          description: "The branch name to use for the preview PR"
-          value: ${{ jobs.branch.outputs.BRANCH_NAME }}
+  workflow_call:
+    outputs:
+      BRANCH_NAME:
+        description: 'The branch name to use for the preview PR'
+        value: ${{ jobs.branch.outputs.BRANCH_NAME }}
 jobs:
   branch:
     runs-on: ubuntu-latest
     outputs:
       BRANCH_NAME: ${{ steps.get_branch_name.outputs.BRANCH_NAME }}
-    
+
     steps:
       - name: Get branch name
         id: get_branch_name
         run: echo "BRANCH_NAME=auto-deployment/developer-portal-pr-${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-

--- a/.github/workflows/get-short-sha.yaml
+++ b/.github/workflows/get-short-sha.yaml
@@ -1,19 +1,19 @@
 name: Get short sha
-
+permissions: {}
 on:
-    workflow_call:
-      outputs:
-        SHORT_SHA:
-          description: "The short sha value in the format sha-abc457"
-          value: ${{ jobs.sha.outputs.SHORT_SHA }}
+  workflow_call:
+    outputs:
+      SHORT_SHA:
+        description: 'The short sha value in the format sha-abc457'
+        value: ${{ jobs.sha.outputs.SHORT_SHA }}
 jobs:
   sha:
     runs-on: ubuntu-latest
     outputs:
       SHORT_SHA: ${{ steps.get_sha.outputs.GITHUB_SHA_SHORT }}
-    
+
     steps:
-      # This assumes that sha was used as a tag in the build job 
+      # This assumes that sha was used as a tag in the build job
       # See https://github.com/docker/metadata-action/issues/164 for discussion about the list
       # of tags returned from metadata-action and using github.sha
       - name: Get short sha

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,6 @@
 name: Run Unit Tests
-
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -2,12 +2,11 @@
 # Create a pull request if the backstage-cli has an updated version
 
 name: 'Version Bump'
+permissions:
+  contents: write
+  pull-requests: write
 on:
   workflow_dispatch:
-
-  # Run at midnight every Monday
-  schedule:
-    - cron: '0 0 * * 1'
 
 env:
   HUSKY: 0
@@ -91,6 +90,8 @@ jobs:
       - name: 'Run backstage-cli versions command'
         if: ${{ steps.branch_created.outputs.CREATED_BRANCH == 1 }}
         run: yarn backstage-cli versions:bump --release 'main'
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
       - name: 'Check for changes'
         if: ${{ steps.branch_created.outputs.CREATED_BRANCH == 1 }}


### PR DESCRIPTION
This PR does the following:

- Add permissions to workflows
- Update the version-bump.yaml file
  - Add `YARN_ENABLE_IMMUTABLE_INSTALLS: false` to backstage version:bump
  - Removed the cron job that ran weekly. We never used the PRs generated from this. However, I would like to keep the workflow and run it manually. As it is helpful when we do upgrade.

