### PR TITLE
Update DevHub Content to Reference Discussions

### DIFF
--- a/packages/app/src/components/home/HomePageCards.tsx
+++ b/packages/app/src/components/home/HomePageCards.tsx
@@ -19,7 +19,6 @@ import {
 import {
   GitHubSvgIcon,
   RocketChatIcon,
-  StackOverFlowIcon,
 } from '../utils/icons';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import { Link } from 'react-router-dom';
@@ -222,14 +221,6 @@ export const HomePageCards = () => {
   const tools = [
     {
       key: 't1',
-      url: 'https://stackoverflow.developer.gov.bc.ca',
-      label: 'Stack Overflow',
-      icon: <StackOverFlowIcon />,
-      buttonText: 'Ask a question',
-      desc: 'Ask, answer and discuss technical questions specific to the B.C. government on the popular Q & A platform.',
-    },
-    {
-      key: 't2',
       url: 'https://chat.developer.gov.bc.ca',
       label: 'RocketChat',
       icon: <RocketChatIcon />,
@@ -237,12 +228,20 @@ export const HomePageCards = () => {
       desc: 'Connect on an open-source team communication app that offers real-time chat, file sharing and collaboration features.',
     },
     {
-      key: 't3',
+      key: 't2',
       url: 'https://github.com/bcgov',
       label: 'GitHub',
       icon: <GitHubSvgIcon />,
       buttonText: 'Find code',
       desc: 'Work together on a web-based version control platform that enables developers to host, review and manage code repositories.',
+    },
+    {
+      key: 't3',
+      url: 'https://github.com/bcgov/bcgov-community-discussions',
+      label: 'Discussions',
+      icon: <GitHubSvgIcon />,
+      buttonText: 'Ask a question',
+      desc: 'Ask, answer and discuss technical questions specific to the B.C. government. Join the bcgov GitHub organization for access!',
     },
   ];
 

--- a/packages/app/src/components/utils/icons.tsx
+++ b/packages/app/src/components/utils/icons.tsx
@@ -38,27 +38,6 @@ export const GitHubSvgIcon = createSvgIcon(
   'GitHub',
 );
 
-// @see https://icon-sets.iconify.design/logos/stackoverflow-icon/
-export const StackOverFlowIcon = createSvgIcon(
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="20"
-    height="23.75"
-    viewBox="0 0 256 304"
-  >
-    <rect x="0" y="0" width="256" height="304" fill="none" stroke="none" />
-    <path
-      fill="#BCBBBB"
-      d="M216.33 276.188v-81.211h26.953v108.165H0V194.977h26.954v81.211z"
-    />
-    <path
-      fill="#F48023"
-      d="m56.708 187.276l132.318 27.654l5.6-26.604L62.31 160.672l-5.601 26.604Zm17.502-63.009l122.517 57.058l11.202-24.503L85.412 99.414L74.21 124.267Zm33.955-60.208l103.964 86.462l17.152-20.653l-103.964-86.462l-17.152 20.653ZM175.375 0L153.67 16.102l80.511 108.515l21.703-16.102L175.375 0ZM53.906 248.884h135.119V221.93H53.907v26.954Z"
-    />
-  </svg>,
-  'StackOverflow',
-);
-
 // @see https://icon-sets.iconify.design/logos/openshift/
 export const OpenShiftSvgIcon = createSvgIcon(
   <svg


### PR DESCRIPTION
## Update DevHub Content to Reference Discussions

This ended up being pretty minimal. This PR just swaps out the Stack Overflow card on the landing page for a Discussions card.

* "tools" cards now mention Discussions instead of SO, also changed the order so that Discussions follows the GitHub card.
* Removed the Stack Overflow icon

<img width="1347" height="351" alt="image" src="https://github.com/user-attachments/assets/6d18ad07-5f9b-4737-a59e-771e33660e89" />  

There's also [this PR](https://github.com/bcgov/bcdg/pull/77) for the BC Developer Guide
