### PR TITLE
Update announcement banner for Discussions

### DIFF
--- a/packages/app/src/components/home/AnnounceBanner.tsx
+++ b/packages/app/src/components/home/AnnounceBanner.tsx
@@ -18,6 +18,7 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     alignItems: 'center',
     gap: tokens.layoutMarginSmall,
+    marginLeft: tokens.layoutMarginMedium,
   },
   closeBtn: {
     marginLeft: tokens.layoutMarginXxlarge,
@@ -34,11 +35,11 @@ export const AnnounceBanner = ({
   ...props
 }: PropsWithChildren<AnnounceBannerProps>) => {
   const classes = useStyles();
-  const bannerStateId = localStorage.getItem('announceBannerStateId');
   // show the banner if announceBannerStateId is unset, or for a previous announcement
-  const [isOpen, setIsOpen] = useState(
-    !bannerStateId || +bannerStateId < props.id,
-  );
+  const [isOpen, setIsOpen] = useState(() => {
+    const bannerStateId = localStorage.getItem('announceBannerStateId');
+    return !bannerStateId || +bannerStateId < props.id;
+  });
 
   if (!isOpen) return null;
 

--- a/packages/app/src/components/home/AnnounceBanner.tsx
+++ b/packages/app/src/components/home/AnnounceBanner.tsx
@@ -25,8 +25,14 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+export enum AnnouncementIds {
+  Wizards = 0,
+  Discussions,
+  // add new announcement ids here
+}
+
 interface AnnounceBannerProps {
-  id: number; // increment the element's id for new announcements
+  id: AnnouncementIds; // increment the element's id for new announcements
   title: string;
 }
 
@@ -38,7 +44,7 @@ export const AnnounceBanner = ({
   // show the banner if announceBannerStateId is unset, or for a previous announcement
   const [isOpen, setIsOpen] = useState(() => {
     const bannerStateId = localStorage.getItem('announceBannerStateId');
-    return !bannerStateId || +bannerStateId < props.id;
+    return !bannerStateId || parseInt(bannerStateId, 10) < props.id;
   });
 
   if (!isOpen) return null;

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -5,7 +5,7 @@ import { makeStyles, Typography } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 import { BCGovBannerText, BCGovHeaderText } from './HomeHeaderText';
 import { HomePageCards } from './HomePageCards';
-import { AnnounceBanner } from './AnnounceBanner';
+import { AnnounceBanner, AnnouncementIds } from './AnnounceBanner';
 import * as tokens from '@bcgov/design-tokens/js';
 
 const useStyles = makeStyles({
@@ -71,7 +71,7 @@ const HomePage = () => {
     <Page themeId="home">
       <GlobalStyle />
       <Content>
-        <AnnounceBanner id={1} title="Search GitHub Discussions">
+        <AnnounceBanner id={AnnouncementIds.Discussions} title="Search GitHub Discussions">
           <Typography>
             <Link to="/settings">Sign In</Link>
             {' '}to enable searching GitHub Discussions directly from DevHub

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -6,7 +6,6 @@ import { Link } from 'react-router-dom';
 import { BCGovBannerText, BCGovHeaderText } from './HomeHeaderText';
 import { HomePageCards } from './HomePageCards';
 import { AnnounceBanner } from './AnnounceBanner';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import * as tokens from '@bcgov/design-tokens/js';
 
 const useStyles = makeStyles({
@@ -67,23 +66,17 @@ const GlobalStyle = createGlobalStyle`
 
 const HomePage = () => {
   const classes = useStyles();
-  const config = useApi(configApiRef);
-  const wizardsEnabled =
-    config.getOptionalConfig('app.wizards') &&
-    config.getBoolean('app.wizards.enabled');
 
   return (
     <Page themeId="home">
       <GlobalStyle />
       <Content>
-        {wizardsEnabled ? (
-          <AnnounceBanner id={0} title="Quickstart wizards launch">
-            <Typography>
-              reduce startup times for new apps with the{' '}
-              <Link to="/create">OpenShift quickstart wizard</Link>
-            </Typography>
-          </AnnounceBanner>
-        ) : null}
+        <AnnounceBanner id={1} title="Search GitHub Discussions">
+          <Typography>
+            <Link to="/settings">Sign In</Link>
+            {' '}to enable searching GitHub Discussions directly from DevHub
+          </Typography>
+        </AnnounceBanner>
 
         <div className={classes.root}>
           <BCGovBannerText variant="h2" gutterBottom>


### PR DESCRIPTION
## GitHub Discussions Announcement Banner update

* Changed the Announcement Banner to Discussions launch w/ Sign In prompt
* Removed app-config check for the banner that was specific to the Wizards launch
* Moved `localStorage.getItem` call to initializer function so it's only called once

<img width="890" height="59" alt="image" src="https://github.com/user-attachments/assets/aff1aade-9d91-4d01-9b01-a7fc4483c908" />

I opted against linking to the Discussions repo since it 404s if you're not a bcgov member, and content-space is a little tight for the whole spiel about joining. Plus, the Discussions card is on the landing page now.
