### PR TITLE
Add referrerPolicy to youtube iframes

### DIFF
--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -8,6 +8,7 @@
 		name="description"
 		content="The B.C. government DevHub is a place to access common technical documentation, community knowledge bases, code samples and APIs."
 	/>
+	<meta name="referrer" content="strict-origin-when-cross-origin">
 	<!--hack for Devx-1182. ROBOT-CONTENT is set in deployment gitops repo-->
 	<meta name="robots" content="##-ROBOT-CONTENT-##">
 	<meta property="og:locale" content="en_US" />

--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -8,7 +8,6 @@
 		name="description"
 		content="The B.C. government DevHub is a place to access common technical documentation, community knowledge bases, code samples and APIs."
 	/>
-	<meta name="referrer" content="strict-origin-when-cross-origin">
 	<!--hack for Devx-1182. ROBOT-CONTENT is set in deployment gitops repo-->
 	<meta name="robots" content="##-ROBOT-CONTENT-##">
 	<meta property="og:locale" content="en_US" />

--- a/plugins/toc-fix2/src/addons/TocFixer.tsx
+++ b/plugins/toc-fix2/src/addons/TocFixer.tsx
@@ -61,6 +61,10 @@ export const TocFixer = () => {
 	useEffect(() => {
 		iframeReferrer.forEach(match => {
 			match.referrerPolicy = 'strict-origin-when-cross-origin';
+			// Force reload by resetting src
+			const src = match.src;
+			match.src = '';
+			match.src = src;
 		});
 	}, [iframeReferrer]);
 

--- a/plugins/toc-fix2/src/addons/TocFixer.tsx
+++ b/plugins/toc-fix2/src/addons/TocFixer.tsx
@@ -67,11 +67,9 @@ export const TocFixer = () => {
 				return;
 			}
 
-			match.referrerPolicy = 'strict-origin-when-cross-origin';
-			// Force reload of iframe by resetting src
-			const src = match.src;
-			match.src = '';
-			match.src = src;
+			const newIframe = match.cloneNode(true) as HTMLIFrameElement;
+			newIframe.referrerPolicy = 'strict-origin-when-cross-origin';
+			match.parentNode?.replaceChild(newIframe, match);
 		});
 	}, [iframeReferrer]);
 

--- a/plugins/toc-fix2/src/addons/TocFixer.tsx
+++ b/plugins/toc-fix2/src/addons/TocFixer.tsx
@@ -23,6 +23,7 @@ export const TocFixer = () => {
 	const onThisPageHeadingInToc = useShadowRootElements<HTMLImageElement>(['div[data-md-type="toc"] a[href*="on-this-page"]'] );
 	const tocHeading = useShadowRootElements<HTMLLabelElement>(['label[for="__toc"]']);
 	const sidebarScrollWrap = useShadowRootElements<HTMLDivElement>(['div[class=md-sidebar__scrollwrap]']);
+	const iframeReferrer = useShadowRootElements<HTMLIFrameElement>(['iframe[src*="youtube.com"]']);
 
 	useEffect(() => {
 		onThisPageHeading.forEach(match => {
@@ -56,6 +57,12 @@ export const TocFixer = () => {
 			match.style.overflowY = 'hidden';
 		});
 	}, [sidebarScrollWrap]);
+
+	useEffect(() => {
+		iframeReferrer.forEach(match => {
+			match.referrerPolicy = 'strict-origin-when-cross-origin';
+		});
+	}, [iframeReferrer]);
 
 	// Nothing to render directly, so we can just return null.
 	return null;

--- a/plugins/toc-fix2/src/addons/TocFixer.tsx
+++ b/plugins/toc-fix2/src/addons/TocFixer.tsx
@@ -58,6 +58,9 @@ export const TocFixer = () => {
 		});
 	}, [sidebarScrollWrap]);
 
+	// YouTube is requiring Referrer header for embeds, but techdocs DOMPurify strips out referrerpolicy from iframes.
+	// There's an open Backstage PR to add allowedAttributes to TechDocs sanitizer config, which would better address this issue.
+	// https://github.com/backstage/backstage/pull/27793
 	useEffect(() => {
 		iframeReferrer.forEach(match => {
 			match.referrerPolicy = 'strict-origin-when-cross-origin';

--- a/plugins/toc-fix2/src/addons/TocFixer.tsx
+++ b/plugins/toc-fix2/src/addons/TocFixer.tsx
@@ -23,7 +23,7 @@ export const TocFixer = () => {
 	const onThisPageHeadingInToc = useShadowRootElements<HTMLImageElement>(['div[data-md-type="toc"] a[href*="on-this-page"]'] );
 	const tocHeading = useShadowRootElements<HTMLLabelElement>(['label[for="__toc"]']);
 	const sidebarScrollWrap = useShadowRootElements<HTMLDivElement>(['div[class=md-sidebar__scrollwrap]']);
-	// const iframeReferrer = useShadowRootElements<HTMLIFrameElement>(['iframe[src*="youtube.com"]']);
+	const iframeReferrer = useShadowRootElements<HTMLIFrameElement>(['iframe[src*="youtube.com"]']);
 
 	useEffect(() => {
 		onThisPageHeading.forEach(match => {
@@ -61,15 +61,20 @@ export const TocFixer = () => {
 	// YouTube is requiring Referrer header for embeds, but techdocs DOMPurify strips out referrerpolicy from iframes.
 	// There's an open Backstage PR to add allowedAttributes to TechDocs sanitizer config, which would better address this issue.
 	// https://github.com/backstage/backstage/pull/27793
-	// useEffect(() => {
-	// 	iframeReferrer.forEach(match => {
-	// 		match.referrerPolicy = 'strict-origin-when-cross-origin';
-	// 		// Force reload by resetting src
-	// 		const src = match.src;
-	// 		match.src = '';
-	// 		match.src = src;
-	// 	});
-	// }, [iframeReferrer]);
+	useEffect(() => {
+		iframeReferrer.forEach(match => {
+			if (match.referrerPolicy === 'strict-origin-when-cross-origin') {
+				return;
+			}
+
+			console.log('Applying referrerPolicy fix to YouTube iframe');
+			match.referrerPolicy = 'strict-origin-when-cross-origin';
+			// Force reload of iframe by resetting src
+			const src = match.src;
+			match.src = '';
+			match.src = src;
+		});
+	}, [iframeReferrer]);
 
 	// Nothing to render directly, so we can just return null.
 	return null;

--- a/plugins/toc-fix2/src/addons/TocFixer.tsx
+++ b/plugins/toc-fix2/src/addons/TocFixer.tsx
@@ -67,7 +67,6 @@ export const TocFixer = () => {
 				return;
 			}
 
-			console.log('Applying referrerPolicy fix to YouTube iframe');
 			match.referrerPolicy = 'strict-origin-when-cross-origin';
 			// Force reload of iframe by resetting src
 			const src = match.src;

--- a/plugins/toc-fix2/src/addons/TocFixer.tsx
+++ b/plugins/toc-fix2/src/addons/TocFixer.tsx
@@ -23,7 +23,7 @@ export const TocFixer = () => {
 	const onThisPageHeadingInToc = useShadowRootElements<HTMLImageElement>(['div[data-md-type="toc"] a[href*="on-this-page"]'] );
 	const tocHeading = useShadowRootElements<HTMLLabelElement>(['label[for="__toc"]']);
 	const sidebarScrollWrap = useShadowRootElements<HTMLDivElement>(['div[class=md-sidebar__scrollwrap]']);
-	const iframeReferrer = useShadowRootElements<HTMLIFrameElement>(['iframe[src*="youtube.com"]']);
+	// const iframeReferrer = useShadowRootElements<HTMLIFrameElement>(['iframe[src*="youtube.com"]']);
 
 	useEffect(() => {
 		onThisPageHeading.forEach(match => {
@@ -61,15 +61,15 @@ export const TocFixer = () => {
 	// YouTube is requiring Referrer header for embeds, but techdocs DOMPurify strips out referrerpolicy from iframes.
 	// There's an open Backstage PR to add allowedAttributes to TechDocs sanitizer config, which would better address this issue.
 	// https://github.com/backstage/backstage/pull/27793
-	useEffect(() => {
-		iframeReferrer.forEach(match => {
-			match.referrerPolicy = 'strict-origin-when-cross-origin';
-			// Force reload by resetting src
-			const src = match.src;
-			match.src = '';
-			match.src = src;
-		});
-	}, [iframeReferrer]);
+	// useEffect(() => {
+	// 	iframeReferrer.forEach(match => {
+	// 		match.referrerPolicy = 'strict-origin-when-cross-origin';
+	// 		// Force reload by resetting src
+	// 		const src = match.src;
+	// 		match.src = '';
+	// 		match.src = src;
+	// 	});
+	// }, [iframeReferrer]);
 
 	// Nothing to render directly, so we can just return null.
 	return null;


### PR DESCRIPTION
## Fix: Embedded youtube videos aren't working in TechDocs

YouTube expects a valid referrer, but Backstage sets its Referrer Policy to 'no-referrer'.
There's an existing Backstage issue covering the referrer policy: https://github.com/backstage/backstage/issues/31550
And a PR to configure it via app-config: https://github.com/backstage/backstage/pull/31678
It should be noted that we can just change it with a meta tag `<meta name="referrer" content="strict-origin-when-cross-origin">`  but I opted against this since we're bypassing Backstage config and setting it site-wide for an issue that's only effecting YouTube iframes.

Adding `referrerpolicy="strict-origin-when-cross-origin"` to the iframe element resolves the problem, but unfortunately TechDocs uses the DOMPurify library to sanitize attributes including `referrerpolicy`.
There's another open PR to address this issue in Backstage: https://github.com/backstage/backstage/pull/27793
I think this is the proper fix, when it's available.

In the meantime this PR adds a piece of logic to the `TocFixer` TechDocs plugin that sets the `referrerpolicy` for Youtube iframes. I definitely think this is a temporary solution, and that the PR above offers a better long-term solution.

Preview w/ working iframes is available [here](https://f5ff48-developer-portal-dev-dprepo-pr-256-f5ff48-dev.apps.silver.devops.gov.bc.ca/docs/default/component/platform-developer-docs/docs/openshift-projects-and-access/install-the-oc-command-line-tool/)