### PR TITLE
Set noindex based on ROBOTS_INDEX env

### DIFF
--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -8,8 +8,6 @@
 		name="description"
 		content="The B.C. government DevHub is a place to access common technical documentation, community knowledge bases, code samples and APIs."
 	/>
-	<!--hack for Devx-1182. ROBOT-CONTENT is set in deployment gitops repo-->
-	<meta name="robots" content="##-ROBOT-CONTENT-##">
 	<meta property="og:locale" content="en_US" />
 	<meta property="og:site_name" content="DevHub" />
 	<meta property="og:title" content="B.C. government DevHub" />

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,6 +1,25 @@
 import { createBackend } from '@backstage/backend-defaults';
+import { rootHttpRouterServiceFactory } from '@backstage/backend-defaults/rootHttpRouter';
 
 const backend = createBackend();
+
+backend.add(
+  rootHttpRouterServiceFactory({
+    configure({ app, applyDefaults }) {
+      if (process.env.ROBOTS_INDEX !== 'true') {
+        app.use((_req, res, next) => {
+          res.setHeader(
+            'X-Robots-Tag',
+            'noindex, nofollow',
+          );
+          next();
+        });
+      }
+      applyDefaults();
+    },
+  }),
+);
+
 backend.add(import('@backstage/plugin-app-backend'));
 backend.add(import('@backstage/plugin-proxy-backend'));
 backend.add(import('@backstage/plugin-catalog-backend'));

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -6,7 +6,7 @@ const backend = createBackend();
 backend.add(
   rootHttpRouterServiceFactory({
     configure({ app, applyDefaults }) {
-      if (process.env.ROBOTS_INDEX !== 'true') {
+      if (process.env.ROBOTS_INDEX?.toLowerCase()?.trim() !== 'true') {
         app.use((_req, res, next) => {
           res.setHeader(
             'X-Robots-Tag',


### PR DESCRIPTION
- Remove robots meta tag
- Set `noindex` http header based on an env value
- gitops changes will be required for prod
  - Removing the sed command
  - Setting `ROBOTS_INDEX = true` for prod
  - gitops change: [PR #35](https://github.com/bcgov-c/tenant-gitops-f5ff48/pull/35)

Here's the curl output from the preview branch w/o env set

<img width="961" height="45" alt="image" src="https://github.com/user-attachments/assets/bc8ad73a-de12-460e-90c1-3fc2cde4084d" />

And here's an example with the env set

<img width="977" height="47" alt="image" src="https://github.com/user-attachments/assets/bfb0c69a-b3c1-4230-969a-09516d03bcc5" />

