### PR TITLE
APS-4700 Restore software catalog search collator

### DIFF
--- a/packages/app/e2e-tests/app.test.ts
+++ b/packages/app/e2e-tests/app.test.ts
@@ -45,6 +45,20 @@ test.describe('Login not needed to access non-protected pages', () => {
     await expect(page.getByText('Search')).toBeVisible();
   });
 
+  test('software catalog search filter is available', async ({ page }) => {
+    const searchResponse = page.waitForResponse(response => {
+      const url = response.url();
+      return (
+        url.includes('/api/search/query') && url.includes('software-catalog')
+      );
+    });
+
+    await page.goto('/search?query=&types%5B%5D=software-catalog');
+
+    await expect(page.getByText('Software Catalog')).toBeVisible();
+    expect((await searchResponse).status()).toBeLessThan(400);
+  });
+
   test('api-docs are available', async ({ page }) => {
     await page.goto('/api-docs');
     await expect(

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -37,6 +37,7 @@ backend.add(import('@roadiehq/scaffolder-backend-module-utils'));
 backend.add(import('@backstage/plugin-auth-backend'));
 backend.add(import('@backstage/plugin-auth-backend-module-github-provider'));
 backend.add(import('@backstage/plugin-search-backend/alpha')); // github-discussions module requires alpha version
+backend.add(import('@backstage/plugin-search-backend-module-catalog'));
 backend.add(import('@backstage/plugin-search-backend-module-pg'));
 backend.add(import('@backstage/plugin-search-backend-module-techdocs'));
 backend.add(


### PR DESCRIPTION
This PR registers the catalog search backend module that was missed during the backend system migration. Without this module, the search backend rejects queries filtered to the software-catalog type with a 400 InputError.

The software catalog search collator was present before the backend system
migration in 9a7f4c5, where it was registered via DefaultCatalogCollatorFactory
in packages/backend/src/plugins/search.ts. During that migration the old search
plugin was deleted and the new backend module registration added pg, techdocs,
and other search modules, but omitted @backstage/plugin-search-backend-module-catalog.

This restores that missing registration so the backend recognizes and indexes
the software-catalog search type again.

It is possible that this was an intentional omission as the catalog was not in general use at the time; however, the Connected Services Integration Toolkit enhancements that are in development will begin populating the catalog with Dataset and API entities which will need to be included in the global search results.