### PR TITLE
Feature/itk postgres search tuning

### DIFF
--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -22,8 +22,8 @@ search:
   pg:
     highlightOptions:
       useHighlight: true
-      maxWords: 45
-      minWords: 20
+      maxWords: 22
+      minWords: 10
       maxFragments: 2
       # PostgreSQL trims ordinary spaces around this option; non-breaking
       # spaces preserve visual separation between fragments in the UI.

--- a/app-config.production.yaml
+++ b/app-config.production.yaml
@@ -19,6 +19,16 @@ catalog:
       rules:
         - allow: [Component]
 search:
+  pg:
+    highlightOptions:
+      useHighlight: true
+      maxWords: 45
+      minWords: 20
+      maxFragments: 2
+      # PostgreSQL trims ordinary spaces around this option; non-breaking
+      # spaces preserve visual separation between fragments in the UI.
+      fragmentDelimiter: "\u00a0\u00a0...\u00a0\u00a0"
+    normalization: 1
   collators:
     catalog:
       schedule: # same options as in SchedulerServiceTaskScheduleDefinition


### PR DESCRIPTION
## Summary

APS-4734: add Postgres search ranking and snippet tuning to `app-config.production.yaml`.

DevHub already uses PostgreSQL and `@backstage/plugin-search-backend-module-pg`. This change only sets query-time options under the existing `search:` key:

- `highlightOptions` — match-centred snippets, up to 2 fragments, shorter length (`maxWords: 22`, `minWords: 10`)
- `normalization: 1` — stop long documents from dominating ranking
- `fragmentDelimiter` uses non-breaking spaces so PostgreSQL does not trim the spacing around `...`

No plugin, schema, collator, or re-index changes. Auth, catalog, and existing collator config are untouched.

## APS tasks included

- APS-4734: Postgres search ranking and snippet tuning

Internal APS PR (merged into this feature branch): https://github.com/bcgov/developer-portal-aps/pull/1

## Test evidence

- Same `search.pg` values validated on the APS PoC (Gold dev) against `cloud`, `security`, `parks`, and `API`
- After the first pass, snippet length was halved (`maxWords` 45 → 22, `minWords` 20 → 10) because results were too verbose
- Before/after for the `cloud` query. LiDAR (a long dataset record) dropped from 1st to 3rd; Public cloud development guide moved from 3rd to 1st.

**Before**
<img width="2962" height="2226" alt="before-cloud-3" src="https://github.com/user-attachments/assets/1ffaed17-b55b-462d-9fd2-daf1350f4d43" />

**After**
<img width="2962" height="2226" alt="after-cloud-3" src="https://github.com/user-attachments/assets/8474ab04-6f0b-42cd-b85f-9629e71e836f" />

## Impacts

- **Config:** new `search.pg` keys in `app-config.production.yaml` only. Local SQLite (`app-config.yaml`) ignores them.
- **Deployment:** no Helm, schema, or re-index change. Query-time only; takes effect on the next image that includes this file.
- **Security / privacy:** none. No new data stored or exposed.
- **Accessibility:** uses the existing Backstage search highlight UI; no new colour or interaction pattern.
- **Operations:** none beyond rolling the image. Collators and Postgres connection are unchanged.


[APS-4734]: https://dpdd.atlassian.net/browse/APS-4734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ